### PR TITLE
trailing whitespaces are removed by the wiki software, so the later text

### DIFF
--- a/tools/bots.py
+++ b/tools/bots.py
@@ -244,7 +244,7 @@ class OneTimeBot():
 
     @staticmethod
     def save_if_changed(page: Page, text: str, change_msg: str):
-        if text != page.text:
+        if text.rstrip() != page.text:
             page.text = text
             page.save(change_msg, botflag=True)
 

--- a/tools/test_bots.py
+++ b/tools/test_bots.py
@@ -299,6 +299,9 @@ class TestOneTimeBot(TestCase):
         self.MinimalBot.save_if_changed(page_mock, "1", "changed")
         compare(0, len(page_mock.mock_calls))
 
+        self.MinimalBot.save_if_changed(page_mock, "1 ", "changed")
+        compare(0, len(page_mock.mock_calls))
+
     class ExceptionBot(OneTimeBot):
         def task(self):
             raise Exception("Exception")


### PR DESCRIPTION
in the wiki wouldn't have such whitespaces.