### PR TITLE
Add author category page generation

### DIFF
--- a/service/ws_re/register/printer.py
+++ b/service/ws_re/register/printer.py
@@ -40,7 +40,7 @@ class ReRegisterPrinter(CloudBot):
                                 register.get_register_str(print_details=register.author.name != "Hans Gärtner"),
                                 "Register aktualisiert")
                 if register.has_existing_article():
-                    save_if_changed(Page(self.wiki,f"Kategorie:RE:Autor:{register.author.ws_lemma_if_exists}"),
+                    save_if_changed(Page(self.wiki, f"Kategorie:RE:Autor:{register.author.ws_lemma_if_exists}"),
                                     register.get_category_str(),
                                     "Kategorie aktualisiert")
                 overview.append(register.overview_line)

--- a/service/ws_re/register/printer.py
+++ b/service/ws_re/register/printer.py
@@ -19,8 +19,8 @@ class ReRegisterPrinter(CloudBot):
         self.registers = Registers()
 
     def task(self):
-        # self._print_volume()
-        # self._print_alphabetic()
+        self._print_volume()
+        self._print_alphabetic()
         self._print_author()
         self._print_short()
         self._print_pd()

--- a/service/ws_re/register/printer.py
+++ b/service/ws_re/register/printer.py
@@ -19,8 +19,8 @@ class ReRegisterPrinter(CloudBot):
         self.registers = Registers()
 
     def task(self):
-        self._print_volume()
-        self._print_alphabetic()
+        # self._print_volume()
+        # self._print_alphabetic()
         self._print_author()
         self._print_short()
         self._print_pd()
@@ -39,6 +39,10 @@ class ReRegisterPrinter(CloudBot):
                                      f"Altertumswissenschaft/Register/{register.author.ws_lemma_if_exists}"),
                                 register.get_register_str(print_details=register.author.name != "Hans Gärtner"),
                                 "Register aktualisiert")
+                if register.has_existing_article():
+                    save_if_changed(Page(self.wiki,f"Kategorie:RE:Autor:{register.author.ws_lemma_if_exists}"),
+                                    register.get_category_str(),
+                                    "Kategorie aktualisiert")
                 overview.append(register.overview_line)
         overview.append("|}")
         save_if_changed(Page(self.wiki,

--- a/service/ws_re/register/register_types/author.py
+++ b/service/ws_re/register/register_types/author.py
@@ -58,6 +58,12 @@ class AuthorRegister(Register):
                f"\n{self._get_table(print_description=print_details, print_author=print_details)}" \
                f"\n{self._get_footer()}"
 
+    def has_existing_article(self) -> bool:
+        return any(lemma.exists for lemma in self._lemmas)
+
+    def get_category_str(self):
+        return f"{{{{REKategorie/Autor|{self.author.ws_lemma_if_exists}|{self.author.last_name}, {self.author.first_name}}}}}"
+
     @property
     def overview_line(self):
         line = ["|-\n", f"|data-sort-value=\"{self.author.last_name}, {self.author.first_name}\""]

--- a/service/ws_re/register/register_types/author.py
+++ b/service/ws_re/register/register_types/author.py
@@ -62,7 +62,8 @@ class AuthorRegister(Register):
         return any(lemma.exists for lemma in self._lemmas)
 
     def get_category_str(self):
-        return f"{{{{REKategorie/Autor|{self.author.ws_lemma_if_exists}|{self.author.last_name}, {self.author.first_name}}}}}"
+        return f"{{{{REKategorie/Autor|{self.author.ws_lemma_if_exists}"\
+               f"|{self.author.last_name}, {self.author.first_name}}}}}"
 
     @property
     def overview_line(self):

--- a/service/ws_re/register/register_types/test_author.py
+++ b/service/ws_re/register/register_types/test_author.py
@@ -128,6 +128,20 @@ class TestAuthorRegister(BaseTestRegister):
 [[Kategorie:RE:Register|Abel, Herman]]"""
         compare(expected_table_less_details, abel_register.get_register_str(print_details=False))
 
+    def test_has_existing_article(self):
+        abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
+        compare(True, abel_register.has_existing_article())
+
+    def test_has_existing_article_none(self):
+        abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
+        for lemma in abel_register._lemmas:
+            lemma.proof_read = None
+        compare(False, abel_register.has_existing_article())
+
+    def test_get_category_str(self):
+        abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
+        compare("{{REKategorie/Autor|Herman Abel|Abel, Herman}}", abel_register.get_category_str())
+
     def test_overview_line(self):
         abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
         compare("|-\n"

--- a/service/ws_re/register/test_printer.py
+++ b/service/ws_re/register/test_printer.py
@@ -86,17 +86,23 @@ class TestReRegisterPrinter(BaseTestRegister, TestCloudBase):
         with mock.patch("service.ws_re.register.printer.Page") as page_mock:
             printer = ReRegisterPrinter()
             printer._print_author()
-            compare(4, len(page_mock.call_args_list))
+            compare(7, len(page_mock.call_args_list))
             compare(call(None, 'Paulys Realencyclopädie der classischen Altertumswissenschaft/Register/Herman Abel'),
                     page_mock.call_args_list[0])
-            compare(call(None, 'Paulys Realencyclopädie der classischen Altertumswissenschaft/Register/Abert'),
+            compare(call(None, 'Kategorie:RE:Autor:Herman Abel'),
                     page_mock.call_args_list[1])
+            compare(call(None, 'Paulys Realencyclopädie der classischen Altertumswissenschaft/Register/Abert'),
+                    page_mock.call_args_list[2])
+            compare(call(None, 'Kategorie:RE:Autor:Abert'),
+                    page_mock.call_args_list[3])
             compare(call(None, 'Paulys Realencyclopädie der classischen Altertumswissenschaft/'
                                'Register/William Abbott'),
-                    page_mock.call_args_list[2])
+                    page_mock.call_args_list[4])
+            compare(call(None, 'Kategorie:RE:Autor:William Abbott'),
+                    page_mock.call_args_list[5])
             compare(
                 call(None, 'Paulys Realencyclopädie der classischen Altertumswissenschaft/Register/Autorenübersicht'),
-                page_mock.call_args_list[3])
+                page_mock.call_args_list[6])
 
     def test_print_sortkey_map(self):
         with mock.patch("service.ws_re.register.printer.Page") as page_mock:


### PR DESCRIPTION
## Summary
- Add `get_category_str()` to `AuthorRegister` to generate `{{REKategorie/Autor|...|...}}` template strings
- Add `has_existing_article()` to `AuthorRegister` to check if at least one lemma exists
- Generate `Kategorie:RE:Autor:{author}` pages in `_print_author()` for authors with existing articles

## Test plan
- [x] `test_get_category_str` — verifies correct template output
- [x] `test_has_existing_article` — verifies `True` when lemmas have `proof_read` set
- [x] `test_has_existing_article_none` — verifies `False` when no lemmas exist
- [x] `test_print_author` — updated to verify category page creation alongside register pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)