### PR TITLE
Add unittest workflow for PRs

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,20 @@
+name: Unittest
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Dependencies
+        uses: "./.github/actions/dependencies"
+      - name: unittest
+        run: make unittest


### PR DESCRIPTION
## Summary
Adds a dedicated `Unittest` GitHub Actions workflow that runs the project's unit tests on pull requests and pushes to `main`.

Previously only lint (`quality.yml`) and wiki (`wikitest.yml`) checks ran on PRs; the `unittest` Makefile target had no CI coverage.

## Details
- New `.github/workflows/unittest.yml`, mirroring the existing workflow patterns
- Triggers on `pull_request` and pushes to `main`
- Uses the shared `./.github/actions/dependencies` composite action for setup
- Runs `make unittest`, which unsets `WS_REAL_WIKI`/`WS_REAL_DATA`, sets `PYWIKIBOT_NO_USER_CONFIG=1`, and runs `uv run nose2 -v service tools`
- Separate workflow so unit tests get their own status check and run in parallel with lint/wikitest

🤖 Generated with [Claude Code](https://claude.com/claude-code)