### PR TITLE
New scanner task NAUE: correct NACHTRAG/ÜBERSCHRIFT values

### DIFF
--- a/service/ws_re/scanner/base.py
+++ b/service/ws_re/scanner/base.py
@@ -18,6 +18,7 @@ from service.ws_re.scanner.tasks.correct_pd_dates import COPDTask
 from service.ws_re.scanner.tasks.death_re_links import DEALTask
 from service.ws_re.scanner.tasks.death_wp_links import DEWPTask
 from service.ws_re.scanner.tasks.error_handling import ERROTask
+from service.ws_re.scanner.tasks.nachtrag_ueberschrift import NAUETask
 from service.ws_re.scanner.tasks.remove_links import RELITask
 from service.ws_re.scanner.tasks.register_scanner import SCANTask
 from service.ws_re.scanner.tasks.sortkey_from_redirect import SKFRTask
@@ -57,6 +58,7 @@ class ReScanner(CloudBot):
             DATATask,  # write out to Wikidata
             SCANTask,  # write out to Registers
             WAORTask,  # look for Lemma where the content article isn't the first on the page
+            NAUETask,  # correct NACHTRAG/ÜBERSCHRIFT values on multi-article pages
         ]
         if self.debug:
             self.tasks = self.tasks + []

--- a/service/ws_re/scanner/tasks/nachtrag_ueberschrift.py
+++ b/service/ws_re/scanner/tasks/nachtrag_ueberschrift.py
@@ -1,0 +1,11 @@
+from service.ws_re.scanner.tasks.base_task import ReScannerTask
+
+
+class NAUETask(ReScannerTask):
+    def task(self):
+        for idx, article_list in enumerate(self.re_page.splitted_article_list):
+            article = article_list.daten
+            # first article is the main article, everything after it is a Nachtrag,
+            # only the first Nachtrag bears the heading
+            article["NACHTRAG"].value = idx > 0
+            article["ÜBERSCHRIFT"].value = idx == 1

--- a/service/ws_re/scanner/tasks/test_nachtrag_ueberschrift.py
+++ b/service/ws_re/scanner/tasks/test_nachtrag_ueberschrift.py
@@ -1,0 +1,130 @@
+# pylint: disable=protected-access
+from testfixtures import compare
+
+from service.ws_re.scanner.tasks.nachtrag_ueberschrift import NAUETask
+from service.ws_re.scanner.tasks.test_base_task import TaskTestCase
+from service.ws_re.template.re_page import RePage
+
+
+class TestNAUETask(TaskTestCase):
+    def test_single_article_correct(self):
+        self.page_mock.text = """{{REDaten
+|NACHTRAG=OFF
+|ÜBERSCHRIFT=OFF
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": False}, task.run(re_page))
+
+    def test_single_article_gets_corrected(self):
+        self.page_mock.text = """{{REDaten
+|NACHTRAG=ON
+|ÜBERSCHRIFT=ON
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": True}, task.run(re_page))
+        article = re_page.splitted_article_list[0].daten
+        compare(False, article["NACHTRAG"].value)
+        compare(False, article["ÜBERSCHRIFT"].value)
+
+    def test_two_articles_correct(self):
+        self.page_mock.text = """{{REDaten
+}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=ON
+|ÜBERSCHRIFT=ON
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": False}, task.run(re_page))
+
+    def test_second_article_gets_corrected(self):
+        self.page_mock.text = """{{REDaten
+}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=OFF
+|ÜBERSCHRIFT=OFF
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": True}, task.run(re_page))
+        article = re_page.splitted_article_list[1].daten
+        compare(True, article["NACHTRAG"].value)
+        compare(True, article["ÜBERSCHRIFT"].value)
+
+    def test_three_articles_correct(self):
+        self.page_mock.text = """{{REDaten
+}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=ON
+|ÜBERSCHRIFT=ON
+}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=ON
+|ÜBERSCHRIFT=OFF
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": False}, task.run(re_page))
+
+    def test_third_article_gets_corrected(self):
+        self.page_mock.text = """{{REDaten
+}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=ON
+|ÜBERSCHRIFT=ON
+}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=OFF
+|ÜBERSCHRIFT=ON
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": True}, task.run(re_page))
+        article = re_page.splitted_article_list[2].daten
+        compare(True, article["NACHTRAG"].value)
+        compare(False, article["ÜBERSCHRIFT"].value)
+        self.assertTrue("|NACHTRAG=ON\n|ÜBERSCHRIFT=OFF" in str(re_page))
+
+    def test_re_abschnitt_is_ignored(self):
+        self.page_mock.text = """{{REDaten
+}}
+text
+{{REAutor|Autor.}}
+{{REAbschnitt}}
+text
+{{REAutor|Autor.}}
+{{REDaten
+|NACHTRAG=ON
+|ÜBERSCHRIFT=ON
+}}
+text
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        task = NAUETask(None, self.logger)
+        compare({"success": True, "changed": False}, task.run(re_page))


### PR DESCRIPTION
## Summary
- add a new ReScanner task (NAUETask) that corrects the NACHTRAG and ÜBERSCHRIFT parameters of REDaten articles based on their position on the page:
  - first article: NACHTRAG=OFF, ÜBERSCHRIFT=OFF
  - second article: NACHTRAG=ON, ÜBERSCHRIFT=ON
  - every further article: NACHTRAG=ON, ÜBERSCHRIFT=OFF
- REAbschnitt sections are ignored (they carry no template parameters)
- register the task in the ReScanner task list

## Test plan
- 7 new unit tests covering compliant single/two/three-article pages, correction of wrong values at each position, and pages with REAbschnitt sections
- full service.ws_re.scanner suite green (280 tests), pylint 10/10, flake8/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)