### PR TITLE
P921: fall back to P1343 backlinks when no wikipedia article is linked

### DIFF
--- a/service/ws_re/scanner/tasks/wikidata/claims/p921_main_subject.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/p921_main_subject.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import Dict, List, Optional
 
 import pywikibot
+from pywikibot.data import sparql
 
 from service.ws_re.scanner.tasks.wikidata.claims._base import SnakParameter
 from service.ws_re.scanner.tasks.wikidata.claims._typing import ChangedClaimsDict, JsonClaimDict
@@ -10,15 +11,41 @@ from service.ws_re.scanner.tasks.wikidata.claims.claim_factory import ClaimFacto
 class P921MainSubject(ClaimFactory):
     """
     Returns the Claim **main subject** -> **<Item of wikipedia article>**
+
+    If no wikipedia article is linked, fall back to items that already point to the
+    RE article via **described by source** (P1343) -> RE with the qualifier
+    **section, verse, paragraph, or clause** (P958) -> <lemma>.
     """
 
     ERROR_CAT = "RE:Wartung Wikidata (WD!=WS)"
 
+    _BACKLINK_QUERY = """SELECT ?candidate ?REArticle WHERE {
+  ?candidate p:P1343 ?st.
+  ?st ps:P1343 wd:Q1138524;
+    pq:P958 ?REArticle.
+}"""
+    # lazy initialized mapping <lemma without prefix> -> <item id>, shared by all instances
+    _backlink_mapping: Optional[Dict[str, str]] = None
+
     def _get_claim_json(self) -> List[JsonClaimDict]:
+        target_item_id = self._get_item_of_wp_article()
+        if not target_item_id:
+            target_item_id = self.get_backlink_mapping().get(self.re_page.lemma_without_prefix)
+        # if no target was found, there is nothing to connect
+        if not target_item_id:
+            return []
+        # finally create the claim
+        snak = SnakParameter(property_str=self.get_property_string(),
+                             target_type="wikibase-item",
+                             target=target_item_id)
+
+        return [self.create_claim_json(snak, references=[[self._IMPORTED_FROM_WIKISOURCE]])]
+
+    def _get_item_of_wp_article(self) -> Optional[str]:
         wp_article = str(self.re_page.first_article["WIKIPEDIA"].value)
         # if no wp_article is present, there is nothing to connect
         if not wp_article:
-            return []
+            return None
         # handle the case of an implicit de:
         if ":" not in wp_article:
             wp_article = f"de:{wp_article}"
@@ -29,13 +56,30 @@ class P921MainSubject(ClaimFactory):
         try:
             wp_data_item: pywikibot.ItemPage = wp_page.data_item()
         except (pywikibot.exceptions.NoPageError, pywikibot.exceptions.InvalidTitleError):
-            return []
-        # finally create the claim
-        snak = SnakParameter(property_str=self.get_property_string(),
-                             target_type="wikibase-item",
-                             target=wp_data_item.id)
+            return None
+        return str(wp_data_item.id)
 
-        return [self.create_claim_json(snak, references=[[self._IMPORTED_FROM_WIKISOURCE]])]
+    @classmethod
+    def get_backlink_mapping(cls) -> Dict[str, str]:
+        if cls._backlink_mapping is None:
+            query_result = sparql.SparqlQuery().select(cls._BACKLINK_QUERY)
+            cls._backlink_mapping = cls._process_backlink_query(query_result or [])
+        return cls._backlink_mapping
+
+    @staticmethod
+    def _process_backlink_query(query_result: List[Dict[str, str]]) -> Dict[str, str]:
+        mapping: Dict[str, str] = {}
+        ambiguous_lemmas = set()
+        for row in query_result:
+            lemma = row["REArticle"]
+            item_id = row["candidate"].rsplit("/", maxsplit=1)[-1]
+            # if two different items claim the same RE article, no clear target exists
+            if lemma in mapping and mapping[lemma] != item_id:
+                ambiguous_lemmas.add(lemma)
+            mapping[lemma] = item_id
+        for lemma in ambiguous_lemmas:
+            del mapping[lemma]
+        return mapping
 
     def get_claims_to_update(self, data_item: pywikibot.ItemPage) -> ChangedClaimsDict:
         """

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p921_main_subject.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p921_main_subject.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access
+# pylint: disable=protected-access,no-self-use
 import pywikibot
 from pywikibot import ItemPage
 from testfixtures import compare
@@ -11,11 +11,50 @@ from tools.test import real_wiki_test
 
 @real_wiki_test
 class TestP921MainSubject(BaseTestClaimFactory):
+    def setUp(self) -> None:
+        super().setUp()
+        # don't trigger the sparql query for the backlink mapping in tests
+        P921MainSubject._backlink_mapping = {}
+
+    def tearDown(self) -> None:
+        P921MainSubject._backlink_mapping = None
+
     def test__get_claim_json_no_linked_wikipedia_lemma(self):
         re_page = self._create_mock_page(text="{{REDaten}}\ntext\n{{REAutor|Blub}}", title="RE:Aal")
         factory = P921MainSubject(re_page, self.logger)
         claim_json = factory._get_claim_json()
         compare(0, len(claim_json))
+
+    def test__get_claim_json_from_backlink_mapping(self):
+        P921MainSubject._backlink_mapping = {"Aal": "Q212239"}
+        re_page = self._create_mock_page(text="{{REDaten}}\ntext\n{{REAutor|Blub}}", title="RE:Aal")
+        factory = P921MainSubject(re_page, self.logger)
+        claim_json = factory._get_claim_json()
+        compare(212239, claim_json[0]["mainsnak"]["datavalue"]["value"]["numeric-id"])
+        compare(15522295, claim_json[0]["references"][0]["snaks"]["P143"][0]["datavalue"]["value"]["numeric-id"])
+
+    def test__get_claim_json_wikipedia_link_beats_backlink_mapping(self):
+        P921MainSubject._backlink_mapping = {"Aal": "Q54321"}
+        re_page = self._create_mock_page(text="{{REDaten|\nWP=de:Aale}}\ntext\n{{REAutor|Blub}}", title="RE:Aal")
+        factory = P921MainSubject(re_page, self.logger)
+        claim_json = factory._get_claim_json()
+        compare(212239, claim_json[0]["mainsnak"]["datavalue"]["value"]["numeric-id"])
+
+    def test__process_backlink_query(self):
+        query_result = [
+            {"candidate": "http://www.wikidata.org/entity/Q100346248", "REArticle": "Postumius 12a"},
+            {"candidate": "http://www.wikidata.org/entity/Q100347483", "REArticle": "Postumius 66"},
+            # same lemma claimed by two different items -> ambiguous, must be dropped
+            {"candidate": "http://www.wikidata.org/entity/Q11111", "REArticle": "Aal"},
+            {"candidate": "http://www.wikidata.org/entity/Q22222", "REArticle": "Aal"},
+            # same lemma claimed twice by the same item -> not ambiguous
+            {"candidate": "http://www.wikidata.org/entity/Q33333", "REArticle": "Monuste"},
+            {"candidate": "http://www.wikidata.org/entity/Q33333", "REArticle": "Monuste"},
+        ]
+        compare({"Postumius 12a": "Q100346248",
+                 "Postumius 66": "Q100347483",
+                 "Monuste": "Q33333"},
+                P921MainSubject._process_backlink_query(query_result))
 
     def test__get_claim_json_bogus_lemma(self):
         re_page = self._create_mock_page(text="{{REDaten|\nWP=de:Blablub}}\ntext\n{{REAutor|Blub}}", title="RE:Aal")

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p921_main_subject.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p921_main_subject.py
@@ -40,6 +40,17 @@ class TestP921MainSubject(BaseTestClaimFactory):
         claim_json = factory._get_claim_json()
         compare(212239, claim_json[0]["mainsnak"]["datavalue"]["value"]["numeric-id"])
 
+    def test_get_backlink_mapping_real_query(self):
+        # reset the cache preset by setUp, so the real sparql query is executed
+        P921MainSubject._backlink_mapping = None
+        mapping = P921MainSubject.get_backlink_mapping()
+        self.assertGreater(len(mapping), 1000)
+        for lemma, item_id in mapping.items():
+            self.assertIsInstance(lemma, str)
+            self.assertRegex(item_id, r"^Q\d+$")
+        # the second call is served from the cache
+        self.assertIs(mapping, P921MainSubject.get_backlink_mapping())
+
     def test__process_backlink_query(self):
         query_result = [
             {"candidate": "http://www.wikidata.org/entity/Q100346248", "REArticle": "Postumius 12a"},


### PR DESCRIPTION
## Summary

`P921MainSubject` so far only derived the **main subject** claim from the `WP=` parameter of the RE article. Many Wikidata items already point at RE articles the other way around — via **P1343 (described by source) → RE (Q1138524)** with the qualifier **P958 (section) → \<lemma\>** (see https://w.wiki/HqfZ), often because the item was created before the RE article existed.

This PR adds that direction as a fallback:

* first try to derive P921 from the linked Wikipedia article (current behavior, unchanged)
* if that yields nothing, look the lemma up in a dictionary built from the SPARQL query above; on a hit, link P921 to the item that already references the RE article

## Implementation notes

* The old `_get_claim_json` body is extracted into `_get_item_of_wp_article()`; claim structure and the `imported from German Wikisource` reference are unchanged.
* The mapping (`lemma without prefix -> QID`) is fetched once via `pywikibot.data.sparql.SparqlQuery` and cached as a class attribute, so a scanner run costs a single query (currently ~1500 entries).
* If two *different* items claim the same RE article, the lemma is dropped as ambiguous — the bot links nothing rather than guessing. The same item claiming a lemma twice is kept.
* `get_claims_to_update` is untouched, so a fallback-derived target that conflicts with an existing P921 still lands in `RE:Wartung Wikidata (WD!=WS)` instead of being overwritten.

## Tests

* `setUp`/`tearDown` preset the class-level cache so tests never fire the live query (the pre-existing "no WP link" tests would otherwise hit the fallback).
* New tests: fallback builds the correct claim incl. reference, a WP link takes precedence over the mapping, ambiguity/dedup handling of the query result, and the real sparql query (cache reset, executed against the live endpoint, currently ~1500 entries).
* All 15 tests pass with `WS_REAL_WIKI=1`; flake8, pycodestyle, pylint (10/10) and mypy clean.
