### PR TITLE
Add HLTSTask: convert hard RE links to RE siehe template

### DIFF
--- a/service/ws_re/scanner/base.py
+++ b/service/ws_re/scanner/base.py
@@ -20,6 +20,7 @@ from service.ws_re.scanner.tasks.correct_pd_dates import COPDTask
 from service.ws_re.scanner.tasks.death_re_links import DEALTask
 from service.ws_re.scanner.tasks.death_wp_links import DEWPTask
 from service.ws_re.scanner.tasks.error_handling import ERROTask
+from service.ws_re.scanner.tasks.hard_links_to_siehe import HLTSTask
 from service.ws_re.scanner.tasks.nachtrag_ueberschrift import NAUETask
 from service.ws_re.scanner.tasks.register_scanner import SCANTask
 from service.ws_re.scanner.tasks.remove_links import RELITask
@@ -51,6 +52,7 @@ class ReScanner(CloudBot):
             KURZTask,  # add short description
             COKSTask,  # correct Korrekturstand if it is not correct
             SKFRTask,  # set sortkey from redirect if it has a better match
+            HLTSTask,  # convert hard wiki links to RE siehe template
             RELITask,  # remove unwanted RE cross-reference syntax
             DEALTask,  # check for dead links RE internal
             DEWPTask,  # check for dead links to Wikipedia

--- a/service/ws_re/scanner/tasks/hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/hard_links_to_siehe.py
@@ -1,0 +1,45 @@
+import re
+
+import pywikibot
+
+from service.ws_re.scanner.tasks.base_task import ReScannerTask
+from service.ws_re.template.article import Article
+from tools.bots.logger import WikiLogger
+
+
+class HLTSTask(ReScannerTask):
+    """
+    Converts hard wiki links to RE articles into the {{RE siehe}} template.
+
+    Replacements:
+    - "[[RE:Lemma]]" -> "{{RE siehe|Lemma}}"
+    - "[[RE:Lemma|Anchor]]" -> "{{RE siehe|Lemma|Anchor}}"
+    """
+
+    _link_regex = re.compile(r"\[\[RE:([^|\]]+)(?:\|([^\]]+))?]]")
+
+    def __init__(self, wiki: pywikibot.site.BaseSite, logger: WikiLogger, debug: bool = True):
+        super().__init__(wiki, logger, debug)
+
+    @classmethod
+    def _replace(cls, match: re.Match) -> str:
+        lemma = match.group(1)
+        anchor = match.group(2)
+        if anchor:
+            return f"{{{{RE siehe|{lemma}|{anchor}}}}}"
+        return f"{{{{RE siehe|{lemma}}}}}"
+
+    def _fix_text(self, text: str) -> str:
+        return self._link_regex.sub(self._replace, text)
+
+    def task(self) -> bool:
+        for idx, part in enumerate(self.re_page):
+            if isinstance(part, Article):
+                fixed = self._fix_text(part.text)
+                if fixed != part.text:
+                    part.text = fixed
+            elif isinstance(part, str):
+                fixed = self._fix_text(part)
+                if fixed != part:
+                    self.re_page[idx] = fixed
+        return True

--- a/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
@@ -28,9 +28,7 @@ Text mit Links: [[RE:Leben(a)]] und [[RE:Leben(a)|Leben]].
 
     def test_replacements_in_plain_text_segments(self):
         self.page_mock.text = (
-            "Vorab [[RE:Leben(a)|Leben]].\n"
-            "{{REDaten}}\nText im Artikel.\n{{REAutor|Autor.}}\n"
-            "Nachlauf [[RE:Leben(a)]]."
+            "Vorab [[RE:Leben(a)|Leben]].\n{{REDaten}}\nText im Artikel.\n{{REAutor|Autor.}}\nNachlauf [[RE:Leben(a)]]."
         )
         re_page = RePage(self.page_mock)
 

--- a/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
@@ -1,0 +1,50 @@
+from testfixtures import compare
+
+from service.ws_re.scanner.tasks.hard_links_to_siehe import HLTSTask
+from service.ws_re.scanner.tasks.test_base_task import TaskTestCase
+from service.ws_re.template.re_page import RePage
+
+
+class TestHLTSTask(TaskTestCase):
+    def setUp(self):
+        super().setUp()
+        self.task = HLTSTask(None, self.logger)
+
+    def test_replacements_in_article_text(self):
+        self.page_mock.text = """{{REDaten
+}}
+Text mit Links: [[RE:Leben(a)]] und [[RE:Leben(a)|Leben]].
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": True}, result)
+
+        after = re_page[0].text
+        self.assertIn("{{RE siehe|Leben(a)}}", after)
+        self.assertIn("{{RE siehe|Leben(a)|Leben}}", after)
+        self.assertNotIn("[[RE:Leben(a)]]", after)
+        self.assertNotIn("[[RE:Leben(a)|Leben]]", after)
+
+    def test_replacements_in_plain_text_segments(self):
+        self.page_mock.text = (
+            "Vorab [[RE:Leben(a)|Leben]].\n"
+            "{{REDaten}}\nText im Artikel.\n{{REAutor|Autor.}}\n"
+            "Nachlauf [[RE:Leben(a)]]."
+        )
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": True}, result)
+
+        full_text = str(re_page)
+        self.assertIn("Vorab {{RE siehe|Leben(a)|Leben}}.", full_text)
+        self.assertIn("Nachlauf {{RE siehe|Leben(a)}}.", full_text)
+
+    def test_no_change_when_no_hard_links_present(self):
+        self.page_mock.text = """{{REDaten}}
+Im Text stehen nur Vorlagen: {{RE siehe|Anderes(a)|Leben}}.
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": False}, result)


### PR DESCRIPTION
## Summary
- New scanner task `HLTSTask` converts `[[RE:Lemma]]` / `[[RE:Lemma|Anchor]]` hard wiki links into `{{RE siehe|Lemma}}` / `{{RE siehe|Lemma|Anchor}}`
- Wired into `base.py` task list, running before RELI/DEAL so link normalization happens first

## Test plan
- [x] `pytest service/ws_re/scanner/tasks/test_hard_links_to_siehe.py` (3 passed)
- [x] `python -c "import service.ws_re.scanner.base"` sanity import