### PR TITLE
Add missing issue articles to existing RE lemmas

### DIFF
--- a/service/ws_re/register/importer.py
+++ b/service/ws_re/register/importer.py
@@ -5,14 +5,37 @@ from pywikibot import Category, Page, Site
 from pywikibot.site import BaseSite
 
 from service.ws_re.register.lemma import Lemma
+from service.ws_re.register.register_types.volume import VolumeRegister
 from service.ws_re.register.registers import Registers
 from service.ws_re.scanner.tasks.adjust_author import adjust_author, get_author_mapping
+from service.ws_re.template import RE_DATEN, ReDatenException
+from service.ws_re.template.article import Article
+from service.ws_re.template.re_page import RePage
+from service.ws_re.volumes import Volumes
 from tools import save_if_changed
 from tools.bots.cloud_bot import CloudBot
+
+CATEGORY_LINE_REGEX = re.compile(r"^\[\[Kategorie:[^\]]+\]\][^\n]*$")
+
+
+def _split_categories(text: str) -> tuple[str, str]:
+    """
+    Split a text block at the end of a page into the text itself and the categories that follow it.
+
+    :return: text without the categories, the categories
+    """
+    lines = text.split("\n")
+    categories: list[str] = []
+    while lines and (not lines[-1].strip() or CATEGORY_LINE_REGEX.match(lines[-1].strip())):
+        line = lines.pop().strip()
+        if line:
+            categories.insert(0, line)
+    return "\n".join(lines).strip(), "\n".join(categories)
 
 
 class ReImporter(CloudBot):
     _STORE_CATEGORY = "RE:Stammdaten überprüfen"
+    _SHORT_TEXT_CATEGORY = "RE:Kurztext überprüfen"
     _PER_NIGHT = 20
     _MAX_CAT = 1000
 
@@ -44,41 +67,152 @@ class ReImporter(CloudBot):
                     self.new_articles[band][lemma] = article
 
     def task(self):
-        # pylint: disable=too-many-nested-blocks
-        create_count = 0
+        edit_count = 0
         for register in self.registers.volumes.values():
-            if create_count >= self.max_create:
+            if edit_count >= self.max_create:
                 break
             for idx, article in enumerate(register):
                 if article.proof_read is None:
                     lemma = Page(self.wiki, f"RE:{article.lemma}")
-                    if not lemma.exists():
-                        article_text = self.get_text(article.volume.name, article.lemma)
-                        if not article_text:
-                            pre_article = register[idx - 1] if idx > 0 else None
-                            try:
-                                post_article = register[idx + 1]
-                            except IndexError:
-                                post_article = None
-                            article_text = self.get_text_backup(article.volume.name, article, pre_article, post_article)
-                        article_text = adjust_author(article_text, self.author_mapping)
-                        article_text = self.adjust_end_column(article_text, register, idx)
-                        article_text = article_text.replace(
-                            "KORREKTURSTAND=Platzhalter", "KORREKTURSTAND=unvollständig"
-                        )
-                        article_text = (
-                            f"{article_text}\n[[Kategorie:{self._STORE_CATEGORY}]]"
-                            "\n[[Kategorie:RE:Kurztext überprüfen]]"
-                        )
-                        save_if_changed(lemma, article_text, "Automatisch generiert")
-                        create_count += 1
-                if create_count >= self.max_create:
+                    article_text = self._compose_article_text(register, idx, article)
+                    if lemma.exists():
+                        # the lemma is already there, the article of this issue is missing on it
+                        if self._add_article(lemma, register.volume.name, article_text):
+                            edit_count += 1
+                    else:
+                        self._create_lemma(lemma, article_text)
+                        edit_count += 1
+                if edit_count >= self.max_create:
                     self.logger.info(
-                        f"Created {create_count} articles. Last article was [[RE:{article.lemma}]]"
+                        f"Edited {edit_count} articles. Last article was [[RE:{article.lemma}]]"
                         f" in {register.volume.name}"
                     )
                     break
         return True
+
+    def _compose_article_text(self, register: VolumeRegister, idx: int, article: Lemma) -> str:
+        article_text = self.get_text(article.volume.name, article.lemma)
+        if not article_text:
+            pre_article = register[idx - 1] if idx > 0 else None
+            try:
+                post_article = register[idx + 1]
+            except IndexError:
+                post_article = None
+            article_text = self.get_text_backup(article.volume.name, article, pre_article, post_article)
+        article_text = adjust_author(article_text, self.author_mapping)
+        article_text = self.adjust_end_column(article_text, register, idx)
+        return article_text.replace("KORREKTURSTAND=Platzhalter", "KORREKTURSTAND=unvollständig")
+
+    def _create_lemma(self, lemma: Page, article_text: str):
+        article_text = (
+            f"{article_text}\n[[Kategorie:{self._STORE_CATEGORY}]]\n[[Kategorie:{self._SHORT_TEXT_CATEGORY}]]"
+        )
+        save_if_changed(lemma, article_text, "Automatisch generiert")
+
+    def _add_article(self, lemma: Page, band: str, article_text: str) -> bool:
+        """
+        Add the article of one issue to an already existing lemma. The article is placed in the order of the
+        issues, all NACHTRAG/ÜBERSCHRIFT flags of the page are adjusted afterwards.
+
+        :param lemma: page of the existing lemma
+        :param band: issue the new article belongs to
+        :param article_text: complete text of the new article
+        :return: True if the page was altered
+        """
+        if "SPALTE_START=OFF" in article_text:
+            # without a start column the register data is too poor to add something to an existing lemma
+            self.logger.info(f"No start column for the article of {band} in [[{lemma.title()}]].")
+            return False
+        if lemma.isRedirectPage():
+            # a redirect isn't a RE article, the redirect must be resolved by hand first
+            self.logger.info(f"[[{lemma.title()}]] is a redirect, the article of {band} can't be added.")
+            return False
+        try:
+            re_page = RePage(lemma)
+        except ReDatenException as error:
+            self.logger.error(f"Can't parse [[{lemma.title()}]] to add the article of {band}. {error.args[0]}")
+            return False
+        self.split_trailing_categories(re_page)
+        try:
+            position = self.get_insert_position(re_page, band)
+        except ReDatenException as error:
+            self.logger.error(f"Can't sort the article of {band} into [[{lemma.title()}]]. {error.args[0]}")
+            return False
+        if position is None:
+            # the article of this issue is already present, nothing to do
+            return False
+        try:
+            new_article = Article.from_text(article_text)
+        except ReDatenException as error:
+            self.logger.error(f"Can't create an article of {band} for [[{lemma.title()}]]. {error.args[0]}")
+            return False
+        re_page.insert(position, new_article)
+        self.adjust_nachtrag(re_page)
+        re_page.add_error_category(self._STORE_CATEGORY)
+        re_page.add_error_category(self._SHORT_TEXT_CATEGORY)
+        try:
+            re_page.save(f"Automatisch ergänzter Artikel aus Band {band}")
+        except ReDatenException as error:
+            self.logger.error(f"Can't save [[{lemma.title()}]] with the added article of {band}. {error.args[0]}")
+            return False
+        return True
+
+    @staticmethod
+    def get_insert_position(re_page: RePage, band: str) -> int | None:
+        """
+        Determine where the article of an issue belongs on a page. The articles are sorted by issue, an article
+        of a later issue is placed behind the articles of all earlier issues.
+
+        :param re_page: page the article should be added to
+        :param band: issue of the new article
+        :return: index in the article list of the page, None if the page already has an article of this issue
+        """
+        volumes = Volumes()
+        sort_key = volumes[band].sort_key
+        position: int | None = None
+        for idx, item in enumerate(re_page):
+            if not isinstance(item, Article) or item.article_type != RE_DATEN:
+                continue
+            existing_band = str(item["BAND"].value)
+            if existing_band == band:
+                return None
+            if position is None and volumes[existing_band].sort_key > sort_key:
+                position = idx
+        if position is not None:
+            return position
+        # the new article is the last one, but the categories at the end of the page must stay at the end
+        last_item = re_page[-1]
+        if isinstance(last_item, str):
+            text, categories = _split_categories(last_item)
+            if categories and not text:
+                return len(re_page) - 1
+        return len(re_page)
+
+    @staticmethod
+    def split_trailing_categories(re_page: RePage):
+        """
+        Split the categories at the end of a page from the text that belongs to the last article of the page.
+        Only then a new article can be placed between that text and the categories.
+        """
+        last_item = re_page[-1]
+        if not isinstance(last_item, str):
+            return
+        text, categories = _split_categories(last_item)
+        if not categories or not text:
+            return
+        re_page[len(re_page) - 1] = text
+        re_page.insert(len(re_page), categories)
+
+    @staticmethod
+    def adjust_nachtrag(re_page: RePage):
+        """
+        The first article of a page is the main article, everything after it is a Nachtrag, only the first
+        Nachtrag bears the heading (same rules as the NAUETask).
+        """
+        daten_articles = [item for item in re_page if isinstance(item, Article) and item.article_type == RE_DATEN]
+        for idx, item in enumerate(daten_articles):
+            item["NACHTRAG"].value = idx > 0
+            item["ÜBERSCHRIFT"].value = idx == 1
 
     def get_text(self, band: str, article: str) -> str | None:
         band_dict = self.new_articles.get(band, None)

--- a/service/ws_re/register/importer.py
+++ b/service/ws_re/register/importer.py
@@ -36,7 +36,7 @@ def _split_categories(text: str) -> tuple[str, str]:
 class ReImporter(CloudBot):
     _STORE_CATEGORY = "RE:Stammdaten überprüfen"
     _SHORT_TEXT_CATEGORY = "RE:Kurztext überprüfen"
-    _PER_NIGHT = 20
+    _PER_NIGHT = 5
     _MAX_CAT = 1000
 
     def __init__(
@@ -146,10 +146,14 @@ class ReImporter(CloudBot):
         except ReDatenException as error:
             self.logger.error(f"Can't create an article of {band} for [[{lemma.title()}]]. {error.args[0]}")
             return False
+        if short_text := self.get_short_text(re_page):
+            # the lemma has a checked short text already, use it instead of the one from the register
+            new_article["KURZTEXT"].value = short_text
+        else:
+            re_page.add_error_category(self._SHORT_TEXT_CATEGORY)
         re_page.insert(position, new_article)
         self.adjust_nachtrag(re_page)
         re_page.add_error_category(self._STORE_CATEGORY)
-        re_page.add_error_category(self._SHORT_TEXT_CATEGORY)
         try:
             re_page.save(f"Automatisch ergänzter Artikel aus Band {band}")
         except ReDatenException as error:
@@ -187,6 +191,14 @@ class ReImporter(CloudBot):
             if categories and not text:
                 return len(re_page) - 1
         return len(re_page)
+
+    @staticmethod
+    def get_short_text(re_page: RePage) -> str:
+        """the short text that is already present on the page, empty if no article of the page has one"""
+        for article in re_page.only_articles:
+            if article.article_type == RE_DATEN and (short_text := str(article["KURZTEXT"].value)):
+                return short_text
+        return ""
 
     @staticmethod
     def split_trailing_categories(re_page: RePage):

--- a/service/ws_re/register/test_importer.py
+++ b/service/ws_re/register/test_importer.py
@@ -115,9 +115,10 @@ class TestGetTextBackup(BaseTestRegister):
         self.assertIn("|NACHFOLGER=NeighborPost", result)
 
 
-def _article(band: str) -> str:
+def _article(band: str, short_text: str = "") -> str:
     return (
-        f"{{{{REDaten\n|BAND={band}\n|NACHTRAG=OFF\n|ÜBERSCHRIFT=OFF\n}}}}\ntext {band}\n{{{{REAutor|Some Author.}}}}"
+        f"{{{{REDaten\n|BAND={band}\n|KURZTEXT={short_text}\n|NACHTRAG=OFF\n|ÜBERSCHRIFT=OFF\n}}}}"
+        f"\ntext {band}\n{{{{REAutor|Some Author.}}}}"
     )
 
 
@@ -153,6 +154,18 @@ class TestAddArticleToLemma(TestCase):
     def test_position_behind_text_of_last_article(self):
         re_page = self._re_page(_article("I A,1"), "<references/>")
         self.assertEqual(2, ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_get_short_text(self):
+        re_page = self._re_page(_article("I A,1", "a short text"), _article("R", "another short text"))
+        self.assertEqual("a short text", ReImporter.get_short_text(re_page))
+
+    def test_get_short_text_of_a_later_article(self):
+        re_page = self._re_page(_article("I A,1"), _article("R", "another short text"))
+        self.assertEqual("another short text", ReImporter.get_short_text(re_page))
+
+    def test_get_short_text_no_short_text_present(self):
+        re_page = self._re_page(_article("I A,1"), _article("R"))
+        self.assertEqual("", ReImporter.get_short_text(re_page))
 
     def test_split_trailing_categories(self):
         re_page = self._re_page(

--- a/service/ws_re/register/test_importer.py
+++ b/service/ws_re/register/test_importer.py
@@ -1,11 +1,14 @@
 # pylint: disable=protected-access,no-self-use
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from service.ws_re.register.authors import Authors
 from service.ws_re.register.importer import ReImporter
 from service.ws_re.register.lemma import Lemma
 from service.ws_re.register.registers import Registers
 from service.ws_re.register.test_base import BaseTestRegister
+from service.ws_re.template import ReDatenException
+from service.ws_re.template.article import Article
+from service.ws_re.template.re_page import RePage
 from service.ws_re.volumes import Volumes
 from tools.test import real_wiki_test
 
@@ -110,3 +113,87 @@ class TestGetTextBackup(BaseTestRegister):
         result = ReImporter.get_text_backup("I,1", article, None, post)
         self.assertIn("|VORGÄNGER=Pre", result)
         self.assertIn("|NACHFOLGER=NeighborPost", result)
+
+
+def _article(band: str) -> str:
+    return (
+        f"{{{{REDaten\n|BAND={band}\n|NACHTRAG=OFF\n|ÜBERSCHRIFT=OFF\n}}}}\ntext {band}\n{{{{REAutor|Some Author.}}}}"
+    )
+
+
+class TestAddArticleToLemma(TestCase):
+    @mock.patch("service.ws_re.template.re_page.pywikibot.Page")
+    @mock.patch("service.ws_re.template.re_page.pywikibot.Page.text", new_callable=mock.PropertyMock)
+    # pylint: disable=arguments-differ
+    def setUp(self, text_mock, page_mock):
+        self.page_mock = page_mock
+        self.text_mock = text_mock
+        type(self.page_mock).text = self.text_mock
+
+    def _re_page(self, *parts: str) -> RePage:
+        self.text_mock.return_value = "\n".join(parts)
+        return RePage(self.page_mock)
+
+    def test_position_before_later_issue(self):
+        re_page = self._re_page(_article("I A,1"), _article("R"))
+        self.assertEqual(1, ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_position_in_front_of_all_articles(self):
+        re_page = self._re_page(_article("R"))
+        self.assertEqual(0, ReImporter.get_insert_position(re_page, "I A,1"))
+
+    def test_position_behind_all_articles(self):
+        re_page = self._re_page(_article("I A,1"))
+        self.assertEqual(1, ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_position_in_front_of_categories(self):
+        re_page = self._re_page(_article("I A,1"), "[[Kategorie:RE:Stammdaten überprüfen]]")
+        self.assertEqual(1, ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_position_behind_text_of_last_article(self):
+        re_page = self._re_page(_article("I A,1"), "<references/>")
+        self.assertEqual(2, ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_split_trailing_categories(self):
+        re_page = self._re_page(
+            _article("I A,1"), "<references/>\n\n[[Kategorie:RE:Stammdaten überprüfen]]\n[[Kategorie:Tada]]"
+        )
+        ReImporter.split_trailing_categories(re_page)
+        self.assertEqual("<references/>", re_page[1])
+        self.assertEqual("[[Kategorie:RE:Stammdaten überprüfen]]\n[[Kategorie:Tada]]", re_page[2])
+        self.assertEqual(2, ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_split_trailing_categories_nothing_to_split(self):
+        re_page = self._re_page(_article("I A,1"), "[[Kategorie:Tada]]")
+        ReImporter.split_trailing_categories(re_page)
+        self.assertEqual(2, len(re_page))
+        re_page = self._re_page(_article("I A,1"), "<references/>")
+        ReImporter.split_trailing_categories(re_page)
+        self.assertEqual(2, len(re_page))
+        re_page = self._re_page(_article("I A,1"))
+        ReImporter.split_trailing_categories(re_page)
+        self.assertEqual(1, len(re_page))
+
+    def test_no_position_issue_already_there(self):
+        re_page = self._re_page(_article("I A,1"), _article("S XIV"), _article("R"))
+        self.assertIsNone(ReImporter.get_insert_position(re_page, "S XIV"))
+
+    def test_unknown_issue_on_page(self):
+        re_page = self._re_page(_article("Tada"))
+        with self.assertRaises(ReDatenException):
+            ReImporter.get_insert_position(re_page, "S XIV")
+
+    def test_adjust_nachtrag(self):
+        re_page = self._re_page(_article("I A,1"), _article("S XIV"), _article("R"))
+        ReImporter.adjust_nachtrag(re_page)
+        flags = [(article["NACHTRAG"].value, article["ÜBERSCHRIFT"].value) for article in re_page.only_articles]
+        self.assertEqual([(False, False), (True, True), (True, False)], flags)
+
+    def test_insert_article_in_page(self):
+        re_page = self._re_page(_article("I A,1"), "[[Kategorie:RE:Stammdaten überprüfen]]")
+        position = ReImporter.get_insert_position(re_page, "S XIV")
+        re_page.insert(position, Article.from_text(_article("S XIV")))
+        ReImporter.adjust_nachtrag(re_page)
+        page_text = str(re_page)
+        self.assertLess(page_text.index("BAND=I A,1"), page_text.index("BAND=S XIV"))
+        self.assertLess(page_text.index("BAND=S XIV"), page_text.index("[[Kategorie:"))

--- a/service/ws_re/register/test_importer.py
+++ b/service/ws_re/register/test_importer.py
@@ -1,4 +1,5 @@
 # pylint: disable=protected-access,no-self-use
+from types import SimpleNamespace
 from unittest import TestCase, mock
 
 from service.ws_re.register.authors import Authors
@@ -10,6 +11,7 @@ from service.ws_re.template import ReDatenException
 from service.ws_re.template.article import Article
 from service.ws_re.template.re_page import RePage
 from service.ws_re.volumes import Volumes
+from tools.bots.test_base import TestCloudBase
 from tools.test import real_wiki_test
 
 
@@ -77,12 +79,23 @@ class TestGetTextBackup(BaseTestRegister):
         self.authors = Authors()
         self.volume = Volumes()["I,1"]
 
-    def _make_lemma(self, lemma: str, previous: str | None = None, next_: str | None = None) -> Lemma:
+    def _make_lemma(
+        self,
+        lemma: str,
+        previous: str | None = None,
+        next_: str | None = None,
+        chapters: list[dict] | None = None,
+        short_description: str | None = None,
+    ) -> Lemma:
         lemma_dict = {"lemma": lemma}
         if previous is not None:
             lemma_dict["previous"] = previous
         if next_ is not None:
             lemma_dict["next"] = next_
+        if chapters is not None:
+            lemma_dict["chapters"] = chapters
+        if short_description is not None:
+            lemma_dict["short_description"] = short_description
         return Lemma.from_dict(lemma_dict, self.volume, self.authors)
 
     def test_uses_article_neighbors_when_set(self):
@@ -113,6 +126,31 @@ class TestGetTextBackup(BaseTestRegister):
         result = ReImporter.get_text_backup("I,1", article, None, post)
         self.assertIn("|VORGÄNGER=Pre", result)
         self.assertIn("|NACHFOLGER=NeighborPost", result)
+
+    def test_columns_author_and_short_description_from_the_chapter(self):
+        article = self._make_lemma(
+            "Main", chapters=[{"start": 12, "end": 14, "author": "Some Author."}], short_description="a short text"
+        )
+        result = ReImporter.get_text_backup("I,1", article)
+        self.assertIn("|SPALTE_START=12", result)
+        self.assertIn("|SPALTE_END=14", result)
+        self.assertIn("|KURZTEXT=a short text", result)
+        self.assertIn("{{REAutor|Some Author.}}", result)
+
+    def test_no_chapter_at_all(self):
+        article = self._make_lemma("Main")
+        result = ReImporter.get_text_backup("I,1", article)
+        self.assertIn("|SPALTE_START=OFF", result)
+        self.assertIn("|SPALTE_END=OFF", result)
+        self.assertIn("|KURZTEXT=\n", result)
+        self.assertIn("{{REAutor|OFF}}", result)
+
+    def test_chapter_without_end_and_author(self):
+        article = self._make_lemma("Main", chapters=[{"start": 12}])
+        result = ReImporter.get_text_backup("I,1", article)
+        self.assertIn("|SPALTE_START=12", result)
+        self.assertIn("|SPALTE_END=OFF", result)
+        self.assertIn("{{REAutor|OFF}}", result)
 
 
 def _article(band: str, short_text: str = "") -> str:
@@ -210,3 +248,224 @@ class TestAddArticleToLemma(TestCase):
         page_text = str(re_page)
         self.assertLess(page_text.index("BAND=I A,1"), page_text.index("BAND=S XIV"))
         self.assertLess(page_text.index("BAND=S XIV"), page_text.index("[[Kategorie:"))
+
+
+NEULAND = """{{REDaten
+|BAND=S XIV
+|SPALTE_START=100
+|KORREKTURSTAND=Platzhalter
+}}
+'''Tada'''
+{{REAutor|Some Author.}}
+1 „RE:Tada“
+"""
+
+
+class PageDouble:
+    """minimal replacement for a pywikibot page, it only knows the things the importer uses"""
+
+    def __init__(self, title: str = "RE:Tada", text: str = "", exists: bool = True, redirect: bool = False):
+        self.text = text
+        self.save_reason = ""
+        self._title = title
+        self._exists = exists
+        self._redirect = redirect
+        self._protection: dict[str, tuple[str, str]] = {}
+
+    def title(self) -> str:
+        return self._title
+
+    def exists(self) -> bool:
+        return self._exists
+
+    def isRedirectPage(self) -> bool:  # naming is given by pywikibot
+        return self._redirect
+
+    def protection(self) -> dict[str, tuple[str, str]]:
+        return self._protection
+
+    def protect_for_sysop(self):
+        self._protection = {"edit": ("sysop", "infinity")}
+
+    def save(self, reason: str, bot: bool = True):  # pylint: disable=unused-argument
+        self.save_reason = reason
+
+
+class LemmaDouble:
+    """minimal replacement for a register lemma"""
+
+    def __init__(self, lemma: str, proof_read: int | None = None, band: str = "S XIV", start: int | None = 100):
+        self.lemma = lemma
+        self.proof_read = proof_read
+        self.volume = SimpleNamespace(name=band)
+        self.previous = "Pre"
+        self.next = "Post"
+        self.short_description = "a short text"
+        self.chapter_objects = [SimpleNamespace(start=start, end=None, author="Some Author.")] if start else []
+
+
+class RegisterDouble:
+    """minimal replacement for a volume register"""
+
+    def __init__(self, lemmas: list[LemmaDouble], band: str = "S XIV"):
+        self._lemmas = lemmas
+        self.volume = SimpleNamespace(name=band)
+
+    def __iter__(self):
+        yield from self._lemmas
+
+    def __getitem__(self, idx: int) -> LemmaDouble:
+        return self._lemmas[idx]
+
+
+class ImporterTestCase(TestCloudBase):
+    def setUp(self):
+        self.page_mock = self._start_patch("Page")
+        self.page_mock.return_value.text = NEULAND
+        self.category_mock = self._start_patch("Category")
+        self.category_mock.return_value.articles.return_value = []
+        self.registers_mock = self._start_patch("Registers")
+        self._start_patch("get_author_mapping").return_value = {}
+        self.importer = ReImporter(wiki=None, debug=True, log_to_screen=False, log_to_wiki=False)
+
+    def _start_patch(self, name: str) -> mock.MagicMock:
+        patcher = mock.patch(f"service.ws_re.register.importer.{name}")
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+
+class TestReImporterInit(ImporterTestCase):
+    def test_articles_from_neuland(self):
+        self.assertEqual({"S XIV": {"Tada": NEULAND.split("\n1 „RE:")[0]}}, self.importer.new_articles)
+
+    def test_get_text(self):
+        self.assertIn("BAND=S XIV", str(self.importer.get_text("S XIV", "Tada")))
+        self.assertIsNone(self.importer.get_text("S XIV", "Other Lemma"))
+        self.assertIsNone(self.importer.get_text("I,1", "Tada"))
+
+    def test_max_create_limited_by_the_category(self):
+        self.assertEqual(self.importer._PER_NIGHT, self.importer.max_create)
+        self.category_mock.return_value.articles.return_value = ["lemma"] * (ReImporter._MAX_CAT - 5)
+        importer = ReImporter(wiki=None, debug=True, log_to_screen=False, log_to_wiki=False)
+        self.assertEqual(5, importer.max_create)
+
+
+class TestCreateLemma(ImporterTestCase):
+    def test_create_lemma(self):
+        page = PageDouble(exists=False)
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.importer._create_lemma(page, _article("S XIV"))
+        text, reason = save_mock.call_args.args[1], save_mock.call_args.args[2]
+        self.assertIn("[[Kategorie:RE:Stammdaten überprüfen]]", text)
+        self.assertIn("[[Kategorie:RE:Kurztext überprüfen]]", text)
+        self.assertEqual("Automatisch generiert", reason)
+
+
+class TestAddArticle(ImporterTestCase):
+    def test_add_article(self):
+        page = PageDouble(text=_article("I A,1", "a checked short text"))
+        self.assertTrue(self.importer._add_article(page, "S XIV", _article("S XIV", "short text of the register")))
+        self.assertLess(page.text.index("BAND=I A,1"), page.text.index("BAND=S XIV"))
+        # the short text of the lemma wins, so the category isn't needed
+        self.assertEqual(2, page.text.count("KURZTEXT=a checked short text"))
+        self.assertNotIn("[[Kategorie:RE:Kurztext überprüfen]]", page.text)
+        self.assertIn("[[Kategorie:RE:Stammdaten überprüfen]]", page.text)
+        self.assertEqual("Automatisch ergänzter Artikel aus Band S XIV", page.save_reason)
+
+    def test_add_article_no_short_text_on_the_page(self):
+        page = PageDouble(text=_article("I A,1"))
+        self.assertTrue(self.importer._add_article(page, "S XIV", _article("S XIV", "short text of the register")))
+        self.assertIn("KURZTEXT=short text of the register", page.text)
+        self.assertIn("[[Kategorie:RE:Kurztext überprüfen]]", page.text)
+
+    def test_add_article_no_start_column(self):
+        page = PageDouble(text=_article("I A,1"))
+        self.assertFalse(self.importer._add_article(page, "S XIV", "{{REDaten\n|SPALTE_START=OFF\n}}"))
+        self.assertEqual("", page.save_reason)
+
+    def test_add_article_lemma_is_a_redirect(self):
+        page = PageDouble(text="#REDIRECT [[RE:Tada 1]]", redirect=True)
+        self.assertFalse(self.importer._add_article(page, "S XIV", _article("S XIV")))
+
+    def test_add_article_page_cant_be_parsed(self):
+        page = PageDouble(text="no article at all")
+        self.assertFalse(self.importer._add_article(page, "S XIV", _article("S XIV")))
+
+    def test_add_article_unknown_issue_on_the_page(self):
+        page = PageDouble(text=_article("Tada"))
+        self.assertFalse(self.importer._add_article(page, "S XIV", _article("S XIV")))
+
+    def test_add_article_issue_already_present(self):
+        page = PageDouble(text=_article("S XIV"))
+        self.assertFalse(self.importer._add_article(page, "S XIV", _article("S XIV")))
+        self.assertEqual("", page.save_reason)
+
+    def test_add_article_new_article_cant_be_parsed(self):
+        page = PageDouble(text=_article("I A,1"))
+        self.assertFalse(self.importer._add_article(page, "S XIV", "{{REDaten\n|SPALTE_START=1\n}}\nno author"))
+
+    def test_add_article_page_is_protected(self):
+        page = PageDouble(text=_article("I A,1"))
+        page.protect_for_sysop()
+        self.assertFalse(self.importer._add_article(page, "S XIV", _article("S XIV")))
+        self.assertEqual("", page.save_reason)
+
+
+class TestTask(ImporterTestCase):
+    def _run_task(self, lemmas: list[LemmaDouble], pages: dict[str, PageDouble]) -> bool:
+        self.importer.registers = SimpleNamespace(volumes={"S XIV": RegisterDouble(lemmas)})
+        self.page_mock.side_effect = lambda wiki, title: pages[title]
+        return self.importer.task()
+
+    def test_task_creates_and_adds(self):
+        pages = {
+            "RE:New Lemma": PageDouble("RE:New Lemma", exists=False),
+            "RE:Old Lemma": PageDouble("RE:Old Lemma", text=_article("I A,1")),
+        }
+        lemmas = [LemmaDouble("New Lemma"), LemmaDouble("Old Lemma"), LemmaDouble("Done Lemma", proof_read=2)]
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.assertTrue(self._run_task(lemmas, pages))
+        self.assertEqual(1, save_mock.call_count)
+        self.assertIn("BAND=S XIV", save_mock.call_args.args[1])
+        self.assertIn("BAND=S XIV", pages["RE:Old Lemma"].text)
+
+    def test_task_stops_at_max_create(self):
+        pages = {
+            "RE:Lemma 1": PageDouble("RE:Lemma 1", exists=False),
+            "RE:Lemma 2": PageDouble("RE:Lemma 2", exists=False),
+        }
+        lemmas = [LemmaDouble("Lemma 1"), LemmaDouble("Lemma 2")]
+        self.importer.max_create = 1
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.assertTrue(self._run_task(lemmas, pages))
+        self.assertEqual(1, save_mock.call_count)
+
+    def test_task_nothing_to_do_when_the_budget_is_used_up(self):
+        lemmas = [LemmaDouble("Lemma 1")]
+        self.importer.max_create = 0
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.assertTrue(self._run_task(lemmas, {}))
+        self.assertEqual(0, save_mock.call_count)
+
+    def test_task_last_lemma_of_the_register_has_no_follower(self):
+        pages = {"RE:Lemma 1": PageDouble("RE:Lemma 1", exists=False)}
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.assertTrue(self._run_task([LemmaDouble("Lemma 1")], pages))
+        self.assertIn("|NACHFOLGER=Post", save_mock.call_args.args[1])
+        self.assertIn("|SPALTE_END=OFF", save_mock.call_args.args[1])
+
+    def test_task_end_column_stays_open_if_the_follower_has_no_columns(self):
+        pages = {
+            "RE:Lemma 1": PageDouble("RE:Lemma 1", exists=False),
+            "RE:Lemma 2": PageDouble("RE:Lemma 2", exists=False),
+        }
+        lemmas = [LemmaDouble("Lemma 1"), LemmaDouble("Lemma 2", start=None)]
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.assertTrue(self._run_task(lemmas, pages))
+        self.assertIn("|SPALTE_END=OFF", save_mock.call_args_list[0].args[1])
+
+    def test_task_uses_the_article_of_the_neuland_page(self):
+        pages = {"RE:Tada": PageDouble("RE:Tada", exists=False)}
+        with mock.patch("service.ws_re.register.importer.save_if_changed") as save_mock:
+            self.assertTrue(self._run_task([LemmaDouble("Tada")], pages))
+        self.assertIn("KORREKTURSTAND=unvollständig", save_mock.call_args.args[1])

--- a/service/ws_re/template/re_page.py
+++ b/service/ws_re/template/re_page.py
@@ -176,6 +176,12 @@ class RePage:
         else:
             raise TypeError("You can only append Elements of the type ReArticle")
 
+    def insert(self, index: int, new_item: Article | str):
+        if isinstance(new_item, Article | str):
+            self._article_list.insert(index, new_item)
+        else:
+            raise TypeError("You can only insert Elements of the type ReArticle or plain text")
+
     def __hash__(self):
         hash_value = 0
         for counter, article in enumerate(self._article_list):

--- a/service/ws_re/template/test_re_page.py
+++ b/service/ws_re/template/test_re_page.py
@@ -171,6 +171,18 @@ class TestRePage(TestCase):
         with self.assertRaises(TypeError):
             re_page.append(1)
 
+    def test_insert(self):
+        self.text_mock.return_value = ARTICLE_TEMPLATE
+        re_page = RePage(self.page_mock)
+        article = Article.from_text("{{REDaten}}\ntada\n{{REAutor|Some Author.}}")
+        re_page.insert(0, article)
+        self.assertEqual(2, len(re_page))
+        self.assertEqual("tada", re_page[0].text)
+        re_page.insert(1, "[[Kategorie:Tada]]")
+        self.assertEqual("[[Kategorie:Tada]]", re_page[1])
+        with self.assertRaises(TypeError):
+            re_page.insert(0, 1)
+
     def test_delete(self):
         self.text_mock.return_value = ARTICLE_TEMPLATE + ARTICLE_TEMPLATE.replace("text.", "tada.") + ARTICLE_TEMPLATE
         re_page = RePage(self.page_mock)


### PR DESCRIPTION
## Why

The importer so far only handled lemmas that don't exist yet (`if not lemma.exists()`). All lemmas are created by now, so the remaining gap are lemmas where the article of one issue is missing on an already existing page — mostly supplement articles. A scan over the register data finds **4279** of them (S XIV 531, S X 422, S VII 355, … no gaps in `R`).

## What

`task()` now has two paths for every register entry without `proof_read`:

* page missing → `_create_lemma()`, unchanged behaviour
* page exists → `_add_article()`, adds the missing article to the page

The text of the new article is built exactly as before (`_compose_article_text()` is shared by both paths).

New helpers:

* `get_insert_position()` sorts the new article into the page by `Volume.sort_key`, so first series → second series → supplements → register band. Verified against the printed order of `RE:Selloi` (II A,2 → S V → R) and `RE:Stertinius 14` (III A,2 → S XIV → R), where sort order and publication order disagree.
* `adjust_nachtrag()` sets `NACHTRAG`/`ÜBERSCHRIFT` of all articles of the page by the same rules as the `NAUETask` — needed because a new article of a main volume can push an existing article into the Nachtrag position.
* `split_trailing_categories()` separates the categories at the end of the page from text like `<references/>` or an Anmerkungen block, so the new article is placed behind that text but in front of the categories.
* `RePage.insert()`.

Skipped and logged: register data without a start column, redirects, pages that can't be parsed and pages with an unknown issue.

## Idempotency

The check whether the article of an issue is already there is done on the **text of the page**, not on the register data. The register data keeps `proof_read` empty until the register scanner visits the page again, so a check on the register data alone would add the same article every night.

## Tests

* 13 new tests, 863 tests green, `ruff check` and `ruff format` clean.
* Dry run against the live wikitext of `RE:Rubellius 4` (I A,1 + R, new S XIV article inserted in between) and `RE:Rhipaia ore` (only R, new I A,1 article inserted in front).
