### PR TITLE
Resolve register neighbours by title before sort key

### DIFF
--- a/service/ws_re/register/register_types/volume.py
+++ b/service/ws_re/register/register_types/volume.py
@@ -103,6 +103,17 @@ class VolumeRegister(Register):
                 found_before = True
         return None
 
+    def get_lemma_by_name_or_sort_key(self, lemma_name: str, self_supplement: bool = False) -> Lemma | None:
+        """Resolve a lemma by its exact title first and fall back to the sort key.
+
+        Neighbours are referenced by title in VORGÄNGER/NACHFOLGER. A lemma with a manually
+        deviating sort key (e.g. "Register (Band XXIII)" sorted as "!023 register") can't be
+        found by sort key alone.
+        """
+        return self.get_lemma_by_name(lemma_name, self_supplement) or self.get_lemma_by_sort_key(
+            lemma_name, self_supplement
+        )
+
     def get_index_of_lemma(self, lemma_input: str | Lemma, self_supplement: bool = False) -> int | None:
         if isinstance(lemma_input, str):
             lemma = self.get_lemma_by_name(lemma_input, self_supplement)

--- a/service/ws_re/register/test_data/register_stubs/pylos_bug.json
+++ b/service/ws_re/register/test_data/register_stubs/pylos_bug.json
@@ -1,0 +1,42 @@
+[
+  {
+    "lemma": "Pyloros 3",
+    "previous": "Pyloros 2",
+    "next": "Pylos",
+    "redirect": true,
+    "chapters": [{"start": 2113, "end": 2113}]
+  },
+  {
+    "lemma": "Pylos",
+    "previous": "Pyloros 3",
+    "next": "Pylos 1",
+    "short_description": "Nachtrag",
+    "chapters": [{"start": 2113, "end": 2114}]
+  },
+  {
+    "lemma": "Pylos 1",
+    "previous": "Pylos",
+    "next": "Pylos 2",
+    "chapters": [{"start": 2114, "end": 2128}]
+  },
+  {
+    "lemma": "Puteoli",
+    "previous": "Pulpitum",
+    "next": "Pylos",
+    "chapters": [{"start": 2517}]
+  },
+  {
+    "lemma": "Pylos",
+    "previous": "Puteoli",
+    "next": "Register (Band XXIII)",
+    "short_description": "Nachtrag",
+    "chapters": [{"start": 2517, "end": 2520}]
+  },
+  {
+    "lemma": "Register (Band XXIII)",
+    "previous": "Pylos",
+    "next": "Pyramos 1",
+    "sort_key": "!23 Register",
+    "chapters": [{"start": 2521, "end": 2576}]
+  }
+]

--- a/service/ws_re/register/test_data/register_stubs/valeria_bug.json
+++ b/service/ws_re/register/test_data/register_stubs/valeria_bug.json
@@ -1,0 +1,48 @@
+[
+  {
+    "lemma": "Valerius 382",
+    "previous": "Valerius 381",
+    "next": "Valeria",
+    "chapters": [{"start": 241, "end": 241}]
+  },
+  {
+    "lemma": "Valeria",
+    "previous": "Valerius 382",
+    "next": "Valerius 383",
+    "redirect": true,
+    "chapters": [{"start": 241, "end": 241}]
+  },
+  {
+    "lemma": "Valerius 383",
+    "previous": "Valeria",
+    "next": "Valerius 384",
+    "chapters": [{"start": 242, "end": 242}]
+  },
+  {
+    "lemma": "Valerius 411",
+    "previous": "Valerius 410",
+    "next": "Valerius",
+    "chapters": [{"start": 259, "end": 259}]
+  },
+  {
+    "lemma": "Valerius",
+    "previous": "Valerius 411",
+    "next": "Valeria",
+    "sort_key": "Valerius 500",
+    "redirect": true,
+    "chapters": [{"start": 259, "end": 259}]
+  },
+  {
+    "lemma": "Valeria",
+    "previous": "Valerius",
+    "next": "Valesianus",
+    "sort_key": "Valerius 411z",
+    "chapters": [{"start": 259, "end": 259}]
+  },
+  {
+    "lemma": "Valesianus",
+    "previous": "Valeria",
+    "next": "Valesium",
+    "chapters": [{"start": 259, "end": 259}]
+  }
+]

--- a/service/ws_re/register/test_updater.py
+++ b/service/ws_re/register/test_updater.py
@@ -500,6 +500,61 @@ class TestBugUpdates(BaseTestRegister):
         compare(1189, register.lemmas[10].chapters[0]["start"])
         compare(2, register.lemmas[10].proof_read)
 
+    def test_neighbour_with_deviating_sort_key_next(self):
+        # RE:Pylos, NACHFOLGER "Register (Band XXIII)" is sorted as "!23 Register"
+        copy_tst_data("pylos_bug", "XXIII_2")
+        register = VolumeRegister(Volumes()["XXIII,2"], Authors())
+        update_dict_1 = {
+            "lemma": "Pylos",
+            "previous": "Pyloros 3",
+            "next": "Pylos 1",
+            "proof_read": 1,
+            "chapters": [{"start": 2113, "end": 2114}],
+        }
+        update_dict_2 = {
+            "lemma": "Pylos",
+            "previous": "Puteoli",
+            "next": "Register (Band XXIII)",
+            "proof_read": 2,
+            "chapters": [{"start": 2517, "end": 2520}],
+        }
+        with Updater(register) as updater:
+            compare("update_pre_and_post_exists", updater.update_lemma(update_dict_1, [], self_supplement=True))
+            compare("update_pre_and_post_exists", updater.update_lemma(update_dict_2, [], self_supplement=True))
+        # both lemmas are updated in place, no new one is created
+        compare(6, len(register.lemmas))
+        compare(1, register.lemmas[1].proof_read)
+        compare(2, register.lemmas[4].proof_read)
+        compare("Register (Band XXIII)", register.lemmas[4].next)
+        compare("Pylos", register.lemmas[5].previous)
+
+    def test_neighbour_with_deviating_sort_key_previous(self):
+        # RE:Valeria, VORGÄNGER "Valerius" is sorted as "Valerius 500"
+        copy_tst_data("valeria_bug", "VIII A_1")
+        register = VolumeRegister(Volumes()["VIII A,1"], Authors())
+        update_dict_1 = {
+            "lemma": "Valeria",
+            "previous": "Valerius 382",
+            "next": "Valerius 383",
+            "proof_read": 2,
+            "chapters": [{"start": 241, "end": 241}],
+        }
+        update_dict_2 = {
+            "lemma": "Valeria",
+            "previous": "Valerius",
+            "next": "Valesianus",
+            "proof_read": 3,
+            "chapters": [{"start": 259, "end": 259}],
+        }
+        with Updater(register) as updater:
+            compare("update_pre_and_post_exists", updater.update_lemma(update_dict_1, [], self_supplement=True))
+            compare("update_pre_and_post_exists", updater.update_lemma(update_dict_2, [], self_supplement=True))
+        compare(7, len(register.lemmas))
+        compare(2, register.lemmas[1].proof_read)
+        compare(3, register.lemmas[5].proof_read)
+        compare("Valerius", register.lemmas[5].previous)
+        compare("Valeria", register.lemmas[6].previous)
+
 
 @ddt
 class TestMissingIndices(BaseTestRegister):

--- a/service/ws_re/register/updater.py
+++ b/service/ws_re/register/updater.py
@@ -37,21 +37,21 @@ class Updater:
         if (
             "previous" in lemma_dict
             and "next" in lemma_dict
-            and self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["previous"]))
-            and self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["next"]))
+            and self._register.get_lemma_by_name_or_sort_key(lemma_dict["previous"])
+            and self._register.get_lemma_by_name_or_sort_key(lemma_dict["next"])
         ):
             self._update_pre_and_post_exists(lemma_dict, self_supplement)
             return "update_pre_and_post_exists"
         if (
             "previous" in lemma_dict
-            and self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["previous"]))
+            and self._register.get_lemma_by_name_or_sort_key(lemma_dict["previous"])
             and not self_supplement
         ):
             self._update_pre_exists(lemma_dict)
             return "update_pre_exists"
         if (
             "next" in lemma_dict
-            and self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["next"]))
+            and self._register.get_lemma_by_name_or_sort_key(lemma_dict["next"])
             and not self_supplement
         ):
             self._update_post_exists(lemma_dict)
@@ -102,7 +102,7 @@ class Updater:
             self._try_update_next(lemma_dict, lemma_to_update)
         else:
             self._register[idx + 1].update_lemma_dict({}, ["previous"])
-            if not self._register.get_lemma_by_sort_key(lemma_dict["next"]):
+            if not self._register.get_lemma_by_name_or_sort_key(lemma_dict["next"]):
                 self._register.lemmas.insert(
                     idx + 1,
                     Lemma.from_dict(
@@ -121,7 +121,7 @@ class Updater:
                 self._try_update_previous(lemma_dict, lemma_to_update)
             else:
                 self._register[idx - 1].update_lemma_dict({}, ["next"])
-                if not self._register.get_lemma_by_sort_key(lemma_dict["previous"]):
+                if not self._register.get_lemma_by_name_or_sort_key(lemma_dict["previous"]):
                     self._register.lemmas.insert(
                         idx,
                         Lemma.from_dict(
@@ -132,8 +132,8 @@ class Updater:
                     )
 
     def _update_pre_and_post_exists(self, lemma_dict: LemmaDict, self_supplement: bool):
-        pre_lemma = self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["previous"]))
-        post_lemma = self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["next"]))
+        pre_lemma = self._register.get_lemma_by_name_or_sort_key(lemma_dict["previous"])
+        post_lemma = self._register.get_lemma_by_name_or_sort_key(lemma_dict["next"])
         if pre_lemma and post_lemma:
             pre_idx = self._register.get_index_of_lemma(pre_lemma)
             post_idx = self._register.get_index_of_lemma(post_lemma)
@@ -141,15 +141,11 @@ class Updater:
                 pre_idx_list: list[int] = [pre_idx]
                 post_idx_list: list[int] = [post_idx]
                 if (
-                    pre_lemma := self._register.get_lemma_by_sort_key(
-                        Lemma.make_sort_key(lemma_dict["previous"]), self_supplement
-                    )
+                    pre_lemma := self._register.get_lemma_by_name_or_sort_key(lemma_dict["previous"], self_supplement)
                 ) and (idx := self._register.get_index_of_lemma(pre_lemma, self_supplement=True)):
                     pre_idx_list.append(idx)
                 if (
-                    post_lemma := self._register.get_lemma_by_sort_key(
-                        Lemma.make_sort_key(lemma_dict["next"]), self_supplement
-                    )
+                    post_lemma := self._register.get_lemma_by_name_or_sort_key(lemma_dict["next"], self_supplement)
                 ) and (idx := self._register.get_index_of_lemma(post_lemma, self_supplement=True)):
                     post_idx_list.append(idx)
                 for pre_idx_tmp in pre_idx_list:
@@ -183,7 +179,7 @@ class Updater:
             self._try_update_next_and_previous(lemma_dict, self._register[pre_idx + 1])
 
     def _update_pre_exists(self, lemma_dict: LemmaDict):
-        pre_lemma = self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["previous"]))
+        pre_lemma = self._register.get_lemma_by_name_or_sort_key(lemma_dict["previous"])
         if pre_lemma:
             pre_idx = self._register.get_index_of_lemma(pre_lemma)
         else:
@@ -201,7 +197,7 @@ class Updater:
             self._try_update_previous(lemma_dict, self._register[pre_idx + 1])
 
     def _update_post_exists(self, lemma_dict: LemmaDict):
-        post_lemma = self._register.get_lemma_by_sort_key(Lemma.make_sort_key(lemma_dict["next"]))
+        post_lemma = self._register.get_lemma_by_name_or_sort_key(lemma_dict["next"])
         if post_lemma:
             post_idx = self._register.get_index_of_lemma(post_lemma)
         else:
@@ -219,6 +215,11 @@ class Updater:
             )
             self._try_update_next(lemma_dict, self._register[post_idx])
 
+    @staticmethod
+    def _is_lemma(lemma_name: str, lemma: Lemma) -> bool:
+        """Match a neighbour title against a lemma, title first and sort key as fallback."""
+        return str(lemma.lemma) == lemma_name or Lemma.make_sort_key(lemma_name) == lemma.get_sort_key()
+
     def _try_update_next_and_previous(self, new_lemma_dict: LemmaDict, lemma_to_update: Lemma):
         self._try_update_previous(new_lemma_dict, lemma_to_update)
         self._try_update_next(new_lemma_dict, lemma_to_update)
@@ -233,7 +234,7 @@ class Updater:
                     next_next_lemma: str | None = str(next_lemma.next) if next_lemma.next else None
                     if next_next_lemma:
                         next_lemma_dict["next"] = next_next_lemma
-                    if Lemma.make_sort_key(str(next_lemma_dict["lemma"])) == next_lemma.get_sort_key():
+                    if self._is_lemma(str(next_lemma_dict["lemma"]), next_lemma):
                         next_lemma.update_lemma_dict(next_lemma_dict)
                         with contextlib.suppress(RegisterException):
                             self.try_update_previous_next_of_surrounding_lemmas(next_lemma_dict, next_lemma)
@@ -249,7 +250,7 @@ class Updater:
                 pre_pre_lemma: str | None = str(pre_lemma.previous) if pre_lemma.previous else None
                 if pre_pre_lemma:
                     pre_lemma_dict["previous"] = pre_pre_lemma
-                if Lemma.make_sort_key(pre_lemma_dict["lemma"]) == pre_lemma.get_sort_key():
+                if self._is_lemma(pre_lemma_dict["lemma"], pre_lemma):
                     pre_lemma.update_lemma_dict(pre_lemma_dict)
                     with contextlib.suppress(RegisterException):
                         self.try_update_previous_next_of_surrounding_lemmas(pre_lemma_dict, pre_lemma)


### PR DESCRIPTION
## Problem

The two lemmas stuck in [Kategorie:RE:Nicht ins Register einsortierbar](https://de.wikisource.org/wiki/Kategorie:RE:Nicht_ins_Register_einsortierbar) — **RE:Pylos** and **RE:Valeria** — fail for one shared reason.

Both pages carry two `{{REDaten}}` blocks in the same volume, so `SCANTask._process_from_article_list` sets `self_supplement=True`. In `Updater.update_lemma` that gates off strategies 1, 2, 4 and 5, leaving only `_update_pre_and_post_exists`, whose guard requires **both** neighbours to be resolved via `get_lemma_by_sort_key(Lemma.make_sort_key(name))`.

Exactly one neighbour per page carries a manually deviating sort key in the register, so `get_sort_key()` returns the stored value and the lookup misses:

| Page | Neighbour | `make_sort_key(title)` | stored `sort_key` | found |
|---|---|---|---|---|
| RE:Pylos | `NACHFOLGER=Register (Band XXIII)` | `register band xxiii` | `!023 register` | no |
| RE:Valeria | `VORGÄNGER=Valerius` | `valerivs` | `valerivs 500` | no |

One miss → no strategy → `RegisterException` → `add_error_category`.

The register entries are already correct (`XXIII_2` #713, `VIII A_1` #269). Nothing is missing or mis-sorted — the updater simply can't re-confirm what's there, so the maintenance category is re-added on every run.

## Fix

Neighbours are referenced by **title** in `VORGÄNGER`/`NACHFOLGER`, so resolve by title first and fall back to the sort key.

- `VolumeRegister.get_lemma_by_name_or_sort_key()` — new helper, exact title first, sort key as fallback.
- `updater.py` — every neighbour lookup uses it: the three strategy guards in `update_lemma`, `_update_pre_and_post_exists` (including both `self_supplement` re-lookups), `_update_pre_exists`, `_update_post_exists`, and the two existence checks in `_u_i_s_w_n_c_1`/`_u_i_s_w_n_c_2`.
- `Updater._is_lemma()` — same title-first comparison in `_try_update_next`/`_try_update_previous`, which had the identical blind spot and silently skipped the neighbour's back-link update.

Patching only the guards would have moved the failure into the "shouldn't happen" raise in `_update_pre_and_post_exists`, so the strategy bodies are covered too.

Unchanged: the lookups for a lemma's **own** sort key (`update_lemma` strategy 2 and `_update_by_sortkey`) — those legitimately key on the sort key.

## Verification

Against the live register data, both pages now process both blocks with `update_pre_and_post_exists`, updating in place with no duplicate insertion (register length unchanged at 715 / 1035):

```
XXIII_2   713 'Pylos'   prev='Puteoli'  next='Register (Band XXIII)'
VIII A_1  269 'Valeria' prev='Valerius' next='Valesianus'  sort='valerivs 411z'
```

Reach beyond these two pages: 4905 register lemmas carry a sort key deviating from their title, with 9752 neighbour references pointing at them.

## Tests

`test_neighbour_with_deviating_sort_key_next` / `_previous` in `TestBugUpdates`, with new stubs `pylos_bug.json` and `valeria_bug.json` mirroring the real data shape. Both were confirmed to fail on the old lookup (`RegisterException: No strategy available`) and pass on the new one.

`service/ws_re/register` and `service/ws_re/scanner`: 268 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

## Note, not addressed here

`test_previous_double_lemmas` reports `distance problem VIII A,1, Valeria, 238, 269`. It fails identically on a clean `main` — pre-existing and unrelated — but it flags the same duplicate pair this PR touches, so `_DOUBLE_LEMMAS` probably wants that entry.
