### PR TITLE
Raise test coverage from 96.62% to 99.93%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,9 @@ omit =
     archive/*,
     # offline functions for one time purposes
     service/ws_re/download_upload/*,
+    service/ws_re/_update_items_in_volumes.py,
+    # the integration suite runs in its own scheduled job (WS_REAL_DATA), it is skipped everywhere else
+    service/ws_re/integration_test/*,
     # potential python virtual env
     venv/*,
     # the runner suite copies test modules temporary to a directory, ignore this files

--- a/service/finisher.py
+++ b/service/finisher.py
@@ -162,7 +162,7 @@ class Finisher(CloudBot):
         return True
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     WS_WIKI = Site(code="de", fam="wikisource", user="THEbotIT")
     with Finisher(wiki=WS_WIKI, debug=False, log_to_wiki=True) as bot:
         bot.run()

--- a/service/gl/status.py
+++ b/service/gl/status.py
@@ -134,7 +134,7 @@ class GlStatus(CloudBot):
         return len(searcher.run())
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     WIKI = Site(code="de", fam="wikisource", user="THEbotIT")
     with GlStatus(wiki=WIKI, debug=False) as bot:
         bot.run()

--- a/service/gl/test_status.py
+++ b/service/gl/test_status.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use,protected-access
 from datetime import datetime
+from unittest import mock
 
 from testfixtures import compare
 
@@ -8,6 +9,17 @@ from tools.bots.test_base import TestCloudBase
 
 
 class TestGlStatus(TestCloudBase):
+    def setUp(self):
+        self.searcher_mock = mock.MagicMock()
+        self.petscan_mock = mock.patch("service.gl.status.PetScan").start()
+        self.petscan_mock.return_value = self.searcher_mock
+        self.page_mock = mock.patch("service.gl.status.Page", new_callable=mock.MagicMock).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def tearDown(self):
+        mock.patch.stopall()
+        super().tearDown()
+
     def test_projektstand(self):
         given_file = """aaa
 <!--new line: Liste wird von einem Bot aktuell gehalten.-->
@@ -38,3 +50,85 @@ bbb"""
         bot = GlStatus(None, False)
         for pair in test_array:
             compare(pair[1], bot.to_percent(*pair[0]))
+
+    def test_alle_seiten(self):
+        given = "aaa<!--GLStatus:alle_Seiten-->12345<!---->bbb"
+        compare("aaa<!--GLStatus:alle_Seiten-->54321<!---->bbb", GlStatus.alle_seiten(given, 54321))
+
+    def test_korrigierte_seiten(self):
+        given = "aaa<!--GLStatus:korrigierte_Seiten-->12345<!---->bbb"
+        compare("aaa<!--GLStatus:korrigierte_Seiten-->54321<!---->bbb", GlStatus.korrigierte_seiten(given, 54321))
+
+    def test_fertige_seiten(self):
+        given = "aaa<!--GLStatus:fertige_Seiten-->1234<!---->bbb"
+        compare("aaa<!--GLStatus:fertige_Seiten-->4321<!---->bbb", GlStatus.fertige_seiten(given, 4321))
+
+    def test_year_some_pages_left(self):
+        bot = GlStatus(None, False)
+        with mock.patch.object(GlStatus, "petscan", side_effect=[50, 30, 20]):
+            compare(
+                '<!--GLStatus:1860-->|span style="background-color:#4876FF; '
+                'font-weight: bold"|ca. 80,0 % korrigiert oder fertig<!---->',
+                bot.year(1860, "<!--GLStatus:1860-->something<!---->"),
+            )
+
+    def test_year_rest_is_korrigiert(self):
+        bot = GlStatus(None, False)
+        with mock.patch.object(GlStatus, "petscan", side_effect=[50, 30, 0]):
+            compare(
+                '<!--GLStatus:1860-->|span style="background-color:#F7D700; '
+                'font-weight: bold"|62,5 % fertig, Rest korrigiert<!---->',
+                bot.year(1860, "<!--GLStatus:1860-->something<!---->"),
+            )
+
+    def test_year_all_done(self):
+        bot = GlStatus(None, False)
+        with mock.patch.object(GlStatus, "petscan", side_effect=[10, 0, 0]):
+            compare(
+                '<!--GLStatus:1860-->|span style="background-color:#00FF00; font-weight: bold"|Fertig<!---->',
+                bot.year(1860, "<!--GLStatus:1860-->something<!---->"),
+            )
+
+    def test_petscan_pages(self):
+        self.searcher_mock.run.return_value = ["a", "b", "c"]
+        bot = GlStatus(None, False)
+        compare(3, bot.petscan(["Fertig"]))
+        self.searcher_mock.set_timeout.assert_called_once_with(120)
+        self.searcher_mock.add_namespace.assert_called_once_with(102)
+        self.searcher_mock.set_search_depth.assert_called_once_with(5)
+        compare(
+            [mock.call("Die Gartenlaube"), mock.call("Fertig")], self.searcher_mock.add_positive_category.call_args_list
+        )
+        self.searcher_mock.add_negative_category.assert_not_called()
+
+    def test_petscan_articles_with_negative_categories(self):
+        self.searcher_mock.run.return_value = []
+        bot = GlStatus(None, False)
+        compare(0, bot.petscan([], article=True, not_categories=["Die Gartenlaube Hefte"]))
+        self.searcher_mock.add_namespace.assert_called_once_with(0)
+        self.searcher_mock.add_negative_category.assert_called_once_with("Die Gartenlaube Hefte")
+
+    def test_petscan_for_one_year(self):
+        self.searcher_mock.run.return_value = ["a"]
+        bot = GlStatus(None, False)
+        compare(1, bot.petscan([], year=1860))
+        self.searcher_mock.add_positive_category.assert_called_once_with("Die Gartenlaube (1860)")
+
+    def test_task(self):
+        self.page_mock.return_value.text = "<!--new line: Liste wird von einem Bot aktuell gehalten.-->"
+        with (
+            mock.patch.object(GlStatus, "petscan", return_value=7),
+            GlStatus(wiki=None, debug=False, log_to_wiki=False) as bot,
+        ):
+            self.assertTrue(bot.run())
+        compare("Die Gartenlaube", self.page_mock.call_args[0][1])
+        self.page_mock.return_value.save.assert_called_once_with("Ein neuer Datensatz wurde eingefügt.", bot=True)
+
+    def test_task_debug_uses_user_subpage(self):
+        self.page_mock.return_value.text = "<!--new line: Liste wird von einem Bot aktuell gehalten.-->"
+        with (
+            mock.patch.object(GlStatus, "petscan", return_value=7),
+            GlStatus(wiki=None, debug=True, log_to_wiki=False) as bot,
+        ):
+            self.assertTrue(bot.run())
+        compare("Benutzer:THEbotIT/GlStatus", self.page_mock.call_args[0][1])

--- a/service/list_bots/author_list.py
+++ b/service/list_bots/author_list.py
@@ -97,7 +97,7 @@ class AuthorList(ListBot):
         return author_dict["last_name"]
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     WS_WIKI = Site(code="de", fam="wikisource", user="THEbotIT")
     with AuthorList(wiki=WS_WIKI, debug=True) as bot:
         bot.run()

--- a/service/list_bots/poem_list.py
+++ b/service/list_bots/poem_list.py
@@ -315,7 +315,7 @@ class PoemList(ListBot):
         return self.TITLE_LINK_REGEX.sub(r"\1", potential_link)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     WS_WIKI = Site(code="de", fam="wikisource", user="THEbotIT")
     with PoemList(wiki=WS_WIKI, debug=True) as bot:
         bot.run()

--- a/service/list_bots/test_author_info.py
+++ b/service/list_bots/test_author_info.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pywikibot
 from testfixtures import compare
@@ -12,6 +12,13 @@ class TestAuthorInfo(TestCase):
 
     def setUp(self):
         self.author_info = AuthorInfo(None)
+
+    def test_enrich_without_a_german_description(self):
+        page = mock.MagicMock()
+        page.data_item.return_value.get.return_value = {"descriptions": {"en": "only english"}}
+        author_dict = {"first_name": "A", "last_name": "B", "birth": "1900", "death": "2000", "sortkey": "B, A"}
+        self.author_info.enrich_author_dict(author_dict, page)
+        compare("", author_dict["description"])
 
     @real_wiki_test
     def test_enrich(self):

--- a/service/list_bots/test_list_bot.py
+++ b/service/list_bots/test_list_bot.py
@@ -1,0 +1,96 @@
+# pylint: disable=protected-access
+from typing import ClassVar
+from unittest import mock
+
+from testfixtures import LogCapture, compare
+
+from service.list_bots.list_bot import ListBot
+from tools.bots.test_base import TestCloudBase
+from tools.petscan import PetScan
+from tools.test import PageMock
+
+STATIC_LIST_TEXT = "date line".ljust(150) + "static part of the list"
+
+
+class DummyListBot(ListBot):
+    LIST_LEMMA = "Liste der Dummies"
+    PROPERTY_TEMPLATE = "Personendaten"
+    PROPERTY_MAPPING: ClassVar[dict[str, str]] = {"name": "NAME"}
+
+    def sort_to_list(self) -> list[dict[str, str]]:
+        return [self.data[key] for key in self.data]
+
+    def print_list(self, item_list: list[dict[str, str]]) -> str:
+        return STATIC_LIST_TEXT
+
+    def get_searcher(self) -> PetScan:
+        return PetScan()
+
+
+class TestListBot(TestCloudBase):
+    def setUp(self):
+        self.page_patcher = mock.patch("service.list_bots.list_bot.Page", new_callable=mock.MagicMock)
+        self.page_mock = self.page_patcher.start()
+        self.addCleanup(mock.patch.stopall)
+
+    def tearDown(self):
+        mock.patch.stopall()
+        super().tearDown()
+
+    def test_get_searcher(self):
+        self.assertIsInstance(DummyListBot().get_searcher(), PetScan)
+
+    def test_get_page_infos(self):
+        page = PageMock()
+        page.text = "{{Personendaten\n|NAME=Ein Dummy\n}}"
+        compare({"name": "Ein Dummy"}, DummyListBot().get_page_infos(page))
+
+    def test_task_keeps_the_page_when_only_the_date_changed(self):
+        self.page_mock.return_value.text = "intro\n" + STATIC_LIST_TEXT
+        with (
+            mock.patch.object(DummyListBot, "process_lemmas"),
+            LogCapture() as log_catcher,
+            DummyListBot(log_to_screen=False, log_to_wiki=False) as bot,
+        ):
+            self.assertTrue(bot.run())
+        log_catcher.check_present(
+            ("DummyListBot", "INFO", "Heute gab es keine Änderungen, daher wird die Seite nicht überschrieben.")
+        )
+        self.page_mock.return_value.save.assert_not_called()
+
+    def test_task_saves_a_changed_list(self):
+        self.page_mock.return_value.text = "a completely different list"
+        with (
+            mock.patch.object(DummyListBot, "process_lemmas"),
+            DummyListBot(log_to_screen=False, log_to_wiki=False) as bot,
+        ):
+            self.assertTrue(bot.run())
+        self.page_mock.return_value.save.assert_called_once_with(
+            "Die Liste wurde auf den aktuellen Stand gebracht.", bot=True
+        )
+
+    def test_process_lemmas_stops_on_watchdog(self):
+        lemmas = [f":Lemma{idx}" for idx in range(60)]
+        with (
+            mock.patch.object(DummyListBot, "get_combined_lemma_list", mock.Mock(return_value=(lemmas, 0))),
+            mock.patch.object(DummyListBot, "remove_old_lemmas"),
+            mock.patch.object(DummyListBot, "get_page_infos", mock.Mock(return_value={})),
+            mock.patch.object(DummyListBot, "_watchdog", mock.Mock(return_value=True)),
+            DummyListBot(log_to_screen=False, log_to_wiki=False) as bot,
+        ):
+            bot.data.assign_dict({})
+            bot.process_lemmas()
+            # the watchdog is only asked after the 51st lemma, so everything before is processed
+            compare(52, len(bot.data.keys()))
+
+    def test_process_lemmas_logs_unparsable_lemmas(self):
+        with (
+            mock.patch.object(DummyListBot, "get_combined_lemma_list", mock.Mock(return_value=([":Lemma"], 1))),
+            mock.patch.object(DummyListBot, "remove_old_lemmas"),
+            mock.patch.object(DummyListBot, "get_page_infos", mock.Mock(side_effect=ValueError)),
+            LogCapture() as log_catcher,
+            DummyListBot(log_to_screen=False, log_to_wiki=False) as bot,
+        ):
+            bot.data.assign_dict({})
+            bot.process_lemmas()
+        log_catcher.check_present(("DummyListBot", "ERROR", "lemma Lemma was not parsed correctly."))

--- a/service/protect.py
+++ b/service/protect.py
@@ -85,7 +85,7 @@ class Protect(CloudBot):
 
 # PYWIKIBOT_DIR=/home/erik/.pywikibot_protect
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     WS_WIKI = Site(code="de", fam="wikisource", user="THEprotectIT")
     with Protect(wiki=WS_WIKI, debug=False) as bot:
         bot.run()

--- a/service/runner.py
+++ b/service/runner.py
@@ -12,7 +12,7 @@ from service.ws_re.register.statistic import ReStatistic
 from service.ws_re.scanner.base import ReScanner
 from tools.bot_scheduler import BotScheduler
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())  # type: ignore
     WS_WIKI = Site(code="de", fam="wikisource", user="THEbotIT")
     SCHEDULER = BotScheduler(wiki=WS_WIKI, debug=False)

--- a/service/test_finisher.py
+++ b/service/test_finisher.py
@@ -110,6 +110,19 @@ class TestFinisher(TestCloudBase):
         compare(False, ":Some Overview, Band 4" in self.finisher.data)
         compare(False, ":Another Bd. 01 (1889)" in self.finisher.data)
 
+    def test_task_stops_on_watchdog(self):
+        mock.patch.object(self.finisher, "_get_proofread_pages", return_value=set()).start()
+        mock.patch.object(self.finisher, "_get_current_pages", return_value=[]).start()
+        mock.patch.object(self.finisher, "_get_checked_lemmas_from_current_pages", return_value=[]).start()
+        mock.patch.object(self.finisher, "_get_checked_lemmas_from_petscan", return_value=[":Regular Lemma"]).start()
+        mock.patch.object(self.finisher, "_watchdog", return_value=True).start()
+        has_korrigiert_mock = mock.patch("service.finisher.has_korrigiert_category", return_value=False).start()
+
+        self.finisher.task()
+
+        has_korrigiert_mock.assert_not_called()
+        compare(False, ":Regular Lemma" in self.finisher.data)
+
     def test_try_autocorrect(self):
         before = """{{Navigation2
  |AUTOR      = [[Friedrich von Boetticher]]

--- a/service/test_protect.py
+++ b/service/test_protect.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from unittest import mock
 
 import pywikibot
-from testfixtures import compare
+from testfixtures import LogCapture, StringComparison, compare
 
 from service.protect import Protect
 from tools.bots.test_base import TestCloudBase
@@ -46,6 +46,17 @@ class TestProtect(TestCloudBase):
             bot.run()
         self.protect_mock.assert_called_once_with(
             reason="Schutz fertiger Seiten", protections={"move": "autoconfirmed", "edit": "autoconfirmed"}
+        )
+
+    def test_page_protection_fails_with_an_api_error(self):
+        self.get_combined_lemma_list_mock.return_value = ([":lemma"], 1)
+        self.page_mock.return_value.protection.return_value = {}  # no protection
+        self.page_mock.return_value.categories.return_value = ["Kategorie:Fertig"]
+        self.protect_mock.side_effect = pywikibot.exceptions.APIError("protectednamespace", "not allowed here")
+        with LogCapture() as log_catcher, Protect(wiki=None, debug=False, log_to_wiki=False) as bot:
+            bot.run()
+        log_catcher.check_present(
+            ("Protect", "ERROR", StringComparison("Wasn't able to protect .*, error was .*not allowed here.*"))
         )
 
     def test_3_pages_one_is_protected(self):

--- a/service/test_runner.py
+++ b/service/test_runner.py
@@ -1,0 +1,10 @@
+import importlib
+from unittest import TestCase
+
+
+class TestRunner(TestCase):
+    def test_module_imports(self):
+        # the runner only wires the scheduler together below its __main__ guard, importing it is the
+        # cheapest way to notice a broken import path before the scheduled run does
+        runner = importlib.import_module("service.runner")
+        self.assertTrue(hasattr(runner, "BotScheduler"))

--- a/service/ws_re/register/register_types/test_author.py
+++ b/service/ws_re/register/register_types/test_author.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-self-use,protected-access
 from collections import OrderedDict
 
-from testfixtures import compare
+from testfixtures import StringComparison, compare
 
 from service.ws_re.register.authors import Authors
 from service.ws_re.register.register_types.author import AuthorRegister
@@ -23,6 +23,24 @@ class TestAuthorRegister(BaseTestRegister):
     def test_init(self):
         abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
         compare(4, len(abel_register))
+
+    def test_repr(self):
+        abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
+        compare(
+            StringComparison(r"<AuthorRegister - author:<Author - name:Herman Abel.*>, lemmas:4>"), repr(abel_register)
+        )
+
+    def test_get_item(self):
+        abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
+        compare("Aba 1", abel_register[0].lemma)
+
+    def test_proof_read_counts_open_lemma_of_living_author_as_unv(self):
+        abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)
+        compare((2, 1, 0, 0), abel_register.proof_read)
+        # Abel died 1998, so the lemma is not public domain yet and its status is the public domain
+        # year rather than "UNV" - a proof_read of 0 still has to be counted as unvollständig
+        abel_register[0].proof_read = 0
+        compare((2, 1, 0, 1), abel_register.proof_read)
 
     def test_make_table(self):
         abel_register = AuthorRegister(self.authors.get_author("Herman Abel"), self.authors, self.registers)

--- a/service/ws_re/register/register_types/test_public_domain.py
+++ b/service/ws_re/register/register_types/test_public_domain.py
@@ -29,6 +29,10 @@ class TestPublicDomainRegister(BaseTestRegister):
         pd_2021_register = PublicDomainRegister(2021, self.authors, self.registers)
         compare(6, len(pd_2021_register))
 
+    def test_get_item(self):
+        pd_2021_register = PublicDomainRegister(2021, self.authors, self.registers)
+        compare("Aal", pd_2021_register[0].lemma)
+
     def test_make_table(self):
         pd_2021_register = PublicDomainRegister(2021, self.authors, self.registers)
         expected_table = """{{Tabellenstile}}

--- a/service/ws_re/register/register_types/test_volume.py
+++ b/service/ws_re/register/register_types/test_volume.py
@@ -199,6 +199,19 @@ class TestRegister(BaseTestRegister):
         compare(4, register.get_index_of_lemma(lemma))
         compare(None, register.get_index_of_lemma("Lemma not there"))
 
+    def test_contains(self):
+        copy_tst_data("I_1_base", "I_1")
+        register = VolumeRegister(Volumes()["I,1"], Authors())
+        self.assertTrue("Aal" in register)
+        self.assertFalse("Abracadabra" in register)
+
+    def test_broken_json_file(self):
+        with open(DataRepo.get_data_path().joinpath("I_1.json"), mode="w", encoding="utf-8") as register_file:
+            register_file.write("[{no valid json]")
+        with self.assertRaises(ValueError) as context:
+            VolumeRegister(Volumes()["I,1"], Authors())
+        compare("Decoding error in file I_1", str(context.exception))
+
 
 @skip("only for analysis")
 class TestIntegrationRegister(TestCase):

--- a/service/ws_re/register/test_author.py
+++ b/service/ws_re/register/test_author.py
@@ -48,6 +48,12 @@ class TestAuthor(TestCase):
         author = Author("Test Name", {"death": 1950, "birth": 1900})
         compare(2021, author.year_public_domain)
 
+    def test_ws_lemma_if_exists(self):
+        compare("Test Name", Author("Test Name", {}).ws_lemma_if_exists)
+        # a lemma in another namespace isn't an author page, so the name stays untouched
+        compare("Test Name", Author("Test Name", {"ws_lemma": "Namespace:Tada_lemma"}).ws_lemma_if_exists)
+        compare("Tada_lemma", Author("Test Name", {"ws_lemma": "Tada_lemma"}).ws_lemma_if_exists)
+
     def test_update_bug_remove_death_date(self):
         author = Author("Test Name", {"death": 1950, "birth": 1900, "ws_lemma": "Tada_lemma"})
         author.update_internal_dict({"birth": 1950})

--- a/service/ws_re/register/test_author_crawler.py
+++ b/service/ws_re/register/test_author_crawler.py
@@ -97,6 +97,18 @@ class TestAuthorCrawler(TestCase):
         expect = {"Wünsch.": {"*": "Richard Wünsch", "R": "Albert Wünsch"}}
         compare(expect, self.crawler._extract_mapping(mapping_text))
 
+    def test_extract_mapping_not_compatible_to_regex(self):
+        with self.assertRaises(ValueError):
+            self.crawler._extract_mapping("no mapping at all")
+
+    def test_extract_complex_mapping_not_compatible_to_regex(self):
+        with self.assertRaises(ValueError):
+            self.crawler._extract_complex_mapping("{no complex mapping at all")
+
+    def test_split_author_table_not_compatible_to_regex(self):
+        with self.assertRaises(ValueError):
+            self.crawler._split_author_table("no table at all")
+
     def test_get_mapping(self):
         test_str = """return {
 ["Karlhans Abel."] = "Karlhans Abel",

--- a/service/ws_re/register/test_clean.py
+++ b/service/ws_re/register/test_clean.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from testfixtures import compare
 
+from service.ws_re.register.author import Author
 from service.ws_re.register.clean import CleanAuthors
 from service.ws_re.register.repo import DataRepo
 from service.ws_re.register.test_base import BaseTestRegister, copy_tst_data
@@ -40,6 +41,11 @@ class TestCleanAuthors(BaseTestRegister):
             open(DataRepo.get_data_path().joinpath("authors_mapping.json"), encoding="utf-8") as cleaned_file,
         ):
             compare(json.load(expection_file), json.load(cleaned_file))
+
+    def test_filter_candidates_of_an_author_without_death_year(self):
+        # without a death year at the old author there is nothing to match against
+        old_author = Author("Old Author", {})
+        compare([], CleanAuthors._filter_candidates([Author("New Author", {"death": 1900})], old_author))
 
 
 class TestRemapAuthors(BaseTestRegister):

--- a/service/ws_re/register/test_registers.py
+++ b/service/ws_re/register/test_registers.py
@@ -42,11 +42,12 @@ class TestRegisters(BaseTestRegister):
             if register.start == "d":
                 compare(1, len(register))
                 continue
-            if register.start == "u":
-                compare(0, len(register))
-                continue
-            if register.start == "uf":
+            # u is unified to v, so the "Ueee" lemma has to show up in the v register
+            if register.start == "v":
                 compare(2, len(register))
+                continue
+            if register.start == "vf":
+                compare(0, len(register))
                 continue
         compare(43, i)
 

--- a/service/ws_re/register/test_repo.py
+++ b/service/ws_re/register/test_repo.py
@@ -1,4 +1,6 @@
 # pylint: disable=protected-access,no-self-use
+import importlib.util
+import os
 from datetime import datetime, timedelta
 from os import path
 from pathlib import Path
@@ -20,6 +22,17 @@ class TestDataRepo(TestCase):
     @classmethod
     def tearDownClass(cls):
         clear_tst_path(renew_path=False)
+
+    def test_module_constants_from_the_environment(self):
+        # the module level constants are only evaluated on import, so execute a fresh copy of the
+        # module in its own namespace instead of touching the one the rest of the suite uses
+        spec = importlib.util.find_spec("service.ws_re.register.repo")
+        module = importlib.util.module_from_spec(spec)
+        environment = {"GITHUB_TOKEN": "token", "REGISTER_DATA_PATH": "/tmp/register_data"}
+        with mock.patch.dict(os.environ, environment):
+            spec.loader.exec_module(module)
+        compare("https://token@github.com/the-it/re_register_data.git", module.REPO_URL)
+        compare(Path("/tmp/register_data"), module.PATH_REAL_DATA)
 
     def test_data_path(self):
         compare(Path(__file__).parent.joinpath("data").joinpath("registers"), DataRepo.get_data_path())

--- a/service/ws_re/register/test_statistic.py
+++ b/service/ws_re/register/test_statistic.py
@@ -19,6 +19,7 @@ from service.ws_re.register.statistic import (
     HEADER_HEIGHT,
     LABEL_WIDTH,
     LINE_HEIGHT,
+    ReStatistic,
     _build_row_articles,
     _color_for_lemma,
     _is_public_domain,
@@ -27,6 +28,7 @@ from service.ws_re.register.statistic import (
 )
 from service.ws_re.register.test_base import BaseTestRegister, copy_tst_data
 from service.ws_re.volumes import Volume
+from tools.bots.test_base import TestCloudBase
 
 
 class TestIsPublicDomain(BaseTestRegister):
@@ -437,3 +439,18 @@ class TestCreatePicture(BaseTestRegister):
                     compare(COLOR_GREEN, pixels[LABEL_WIDTH + 48, bar_y])
                     compare(COLOR_GREEN, pixels[LABEL_WIDTH + 50, bar_y])
                     compare(COLOR_GREEN, pixels[LABEL_WIDTH + 101, bar_y])
+
+
+class TestReStatistic(TestCloudBase):
+    def test_task_uploads_the_rendered_overview(self):
+        with (
+            mock.patch("service.ws_re.register.statistic.create_picture") as picture_mock,
+            mock.patch("service.ws_re.register.statistic.FilePage") as file_page_mock,
+            ReStatistic(wiki=None, debug=True, log_to_wiki=False) as bot,
+        ):
+            self.assertTrue(bot.run())
+        compare(1, picture_mock.call_count)
+        compare("File:RE Register Statistik.png", file_page_mock.call_args[0][1])
+        file_page_mock.return_value.upload.assert_called_once_with(
+            mock.ANY, comment="Bearbeitungsstand aktualisiert", ignore_warnings=True
+        )

--- a/service/ws_re/register/test_updater.py
+++ b/service/ws_re/register/test_updater.py
@@ -590,3 +590,31 @@ class TestMissingIndices(BaseTestRegister):
         update_dict = {"lemma": "B", "previous": "Ä", "next": "Ö"}
         with Updater(register) as updater:
             updater.update_lemma(update_dict, [])
+
+    def test_repr(self):
+        copy_tst_data("I_1_base", "I_1")
+        register = VolumeRegister(Volumes()["I,1"], Authors())
+        compare("<Updater - register:I,1>", repr(Updater(register)))
+
+    def test_update_pre_and_post_exists_without_neighbours(self):
+        copy_tst_data("I_1_base", "I_1")
+        register = VolumeRegister(Volumes()["I,1"], Authors())
+        update_dict = {"lemma": "B", "previous": "Not there", "next": "Also not there"}
+        with Updater(register) as updater, self.assertRaises(RegisterException):
+            updater._update_pre_and_post_exists(update_dict, False)
+
+    def test_update_pre_exists_without_previous_lemma(self):
+        copy_tst_data("I_1_base", "I_1")
+        register = VolumeRegister(Volumes()["I,1"], Authors())
+        pre_length = len(register)
+        with Updater(register) as updater:
+            updater._update_pre_exists({"lemma": "B", "previous": "Not there"})
+        compare(pre_length, len(register))
+
+    def test_update_post_exists_without_next_lemma(self):
+        copy_tst_data("I_1_base", "I_1")
+        register = VolumeRegister(Volumes()["I,1"], Authors())
+        pre_length = len(register)
+        with Updater(register) as updater:
+            updater._update_post_exists({"lemma": "B", "next": "Not there"})
+        compare(pre_length, len(register))

--- a/service/ws_re/scanner/tasks/test_add_short_description.py
+++ b/service/ws_re/scanner/tasks/test_add_short_description.py
@@ -2,7 +2,7 @@
 from unittest import mock, skip
 
 import pywikibot
-from testfixtures import compare
+from testfixtures import LogCapture, compare
 
 from service.ws_re.scanner.tasks.add_short_description import KURZTask
 from service.ws_re.scanner.tasks.test_base_task import TaskTestCase
@@ -107,9 +107,43 @@ text
         compare({"success": True, "changed": False}, task.run(re_page))
         compare("", re_page.first_article["KURZTEXT"].value)
 
+    def test_no_short_description_available(self):
+        self.page_mock.text = """{{REDaten}}
+text
+{{REAutor|Autor.}}"""
+        self.page_mock.title_str = "Re:Lemma without a short description"
+        re_page = RePage(self.page_mock)
+        task = KURZTask(None, self.logger)
+        compare({"success": True, "changed": False}, task.run(re_page))
+        compare("", re_page.first_article["KURZTEXT"].value)
+
+
+class TestKURZTaskSourcePages(TaskTestCase):
+    def setUp(self):
+        super().setUp()
+        mock.patch("service.ws_re.scanner.tasks.add_short_description.RE_ALPHABET", ["a"]).start()
+        self.source_page_mock = mock.patch("service.ws_re.scanner.tasks.add_short_description.pywikibot.Page").start()
+        self.addCleanup(mock.patch.stopall)
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_reads_the_lookup_from_the_source_page(self):
+        self.source_page_mock.return_value.text = TEXT_A
+        task = KURZTask(None, self.logger)
+        compare("Zoologisch", task.short_description_lookup["aal"])
+        compare("Wikisource:RE-Werkstatt/Kurzbeschreibung/a", self.source_page_mock.call_args[0][1])
+
+    def test_logs_an_error_for_an_empty_source_page(self):
+        self.source_page_mock.return_value.text = ""
+        with LogCapture() as log_catcher:
+            task = KURZTask(None, self.logger)
+        compare({}, task.short_description_lookup)
+        log_catcher.check_present(("Test", "ERROR", "Couldn't load Wikisource:RE-Werkstatt/Kurzbeschreibung/a."))
+
 
 @skip("only for analysis")
 class TestKURZTaskProcessSourceLoadReality(TaskTestCase):
-    def test_load_real_sources(self):
+    def test_load_real_sources(self):  # pragma: no cover
         task = KURZTask(pywikibot.Site(code="de", fam="wikisource", user="THEbotIT"), self.logger)
         self.assertGreater(len(task.short_description_lookup), 14000)

--- a/service/ws_re/scanner/tasks/test_adjust_author.py
+++ b/service/ws_re/scanner/tasks/test_adjust_author.py
@@ -65,6 +65,20 @@ test
             compare({"success": True, "changed": False}, task.run(re_page))
         compare("Arthur Stein", re_page[0].author.short_string)
 
+    def test_skip_text_outside_of_an_article(self):
+        self.page_mock.text = """{{REDaten
+|BAND=I,1
+|KORREKTURSTAND=unvollständig
+}}
+test
+{{REAutor|Arthur Stein}}
+[[Kategorie:RE:Wartung]]"""
+        re_page = RePage(self.page_mock)
+        with LogCapture():
+            task = ADAUTask(None, self.logger)
+            compare({"success": True, "changed": True}, task.run(re_page))
+        compare("[[Kategorie:RE:Wartung]]", re_page[1])
+
     def test_no_change_for_unknown_author(self):
         self.page_mock.text = """{{REDaten
 |BAND=I,1

--- a/service/ws_re/scanner/tasks/test_base_task.py
+++ b/service/ws_re/scanner/tasks/test_base_task.py
@@ -41,6 +41,15 @@ class TestReScannerTask(TaskTestCase):
         bot = self.NAM1Task(None, WikiLogger(bot_name="Test", start_time=datetime(2000, 1, 1), log_to_screen=False))
         self.assertEqual("NAM1", bot.name)
 
+    class WrongNamedTask(ReScannerTask):
+        def task(self):
+            pass
+
+    def test_name_of_a_wrong_named_class(self):
+        # the name is already needed while loading the task, so the constructor is the one to fail
+        with self.assertRaises(ValueError):
+            self.WrongNamedTask(None, WikiLogger(bot_name="Test", start_time=datetime(2000, 1, 1), log_to_screen=False))
+
     class MINITask(ReScannerTask):
         def task(self):
             return True

--- a/service/ws_re/scanner/tasks/test_check_redirect_links.py
+++ b/service/ws_re/scanner/tasks/test_check_redirect_links.py
@@ -81,6 +81,35 @@ class TestCHRETaskUnittests(TaskTestCase):
         task = CHRETask(None, self.logger)
         compare(expect, task.replace_redirect_links(text, ["Ab", "Abc"], "Target"))
 
+    def test_task_repairs_backlinks_and_reports_them(self):
+        redirect = self._redirect_mock("RE:Alias")
+        redirect.backlinks.return_value = [mock.Mock(**{"title.return_value": "Literatur"})]
+        task = CHRETask(None, self.logger)
+        task.re_page = mock.Mock()
+        # collect_redirect_chain pops from the returned list, so hand out a fresh one per call
+        task.re_page.get_redirects.side_effect = lambda: [redirect]
+        task.re_page.lemma_without_prefix = "Target"
+        with (
+            mock.patch("service.ws_re.scanner.tasks.check_redirect_links.pywikibot.Page") as page_mock,
+            mock.patch("service.ws_re.scanner.tasks.check_redirect_links.time.sleep") as sleep_mock,
+            mock.patch("service.ws_re.scanner.tasks.check_redirect_links.save_if_changed") as save_mock,
+        ):
+            page_mock.return_value.text = "[[RE:Alias]]"
+            self.assertTrue(task.task())
+        compare("[[RE:Target]]", save_mock.call_args[0][1])
+        sleep_mock.assert_called_once_with(2)
+        task.re_page.add_error_category.assert_called_once_with(CHRETask.error_category)
+
+    def test_task_removes_error_category_without_backlinks(self):
+        redirect = self._redirect_mock("RE:Alias")
+        redirect.backlinks.return_value = []
+        task = CHRETask(None, self.logger)
+        task.re_page = mock.Mock()
+        task.re_page.get_redirects.side_effect = lambda: [redirect]
+        self.assertTrue(task.task())
+        task.re_page.add_error_category.assert_not_called()
+        compare(2, task.re_page.remove_error_category.call_count)
+
     def test_filter_link_list(self):
         link_list = [
             "Literatur",

--- a/service/ws_re/scanner/tasks/test_create_ocr.py
+++ b/service/ws_re/scanner/tasks/test_create_ocr.py
@@ -1,8 +1,9 @@
 # pylint: disable=protected-access
 from datetime import datetime
 from pathlib import Path
-from unittest import skip
+from unittest import mock
 
+from botocore.exceptions import ClientError
 from ddt import ddt, file_data
 from testfixtures import compare
 
@@ -63,7 +64,6 @@ class TestCOCRTask(TestCloudBase):
     def test_detect_empty_content(self, given, expect):
         compare(expect, self.task._detect_empty_content(given))
 
-    @skip
     @file_data("test_data/create_ocr/test_get_text_for_article.yml")
     def test_get_text_for_article_single_page(self, given, expect):
         # Arrange: upload OCR page and set page/lemma from fixture
@@ -85,7 +85,6 @@ class TestCOCRTask(TestCloudBase):
         # Assert
         compare(expect.strip(), text)
 
-    @skip
     def test_task_appends_ocr_for_rages(self):
         # Arrange: upload OCR page and create a placeholder article for RE:Rages on page 127
         self.put_page_to_cloud("I A,1_0127")
@@ -109,9 +108,43 @@ class TestCOCRTask(TestCloudBase):
 
         # Assert: the first article's text should now be the OCR section for Rages
         expected = (
-            "'''Rages'''\n[[Kategorie:RE:OCR_erstellt]]\n'''Rages''' s. {{Polytonisch|'Pάγα}} ta."
-            "\n{{Seite|128}}\n[[Kategorie:RE:OCR_Seite_nicht_gefunden]]"
+            "'''Rages'''\n[[Kategorie:RE:OCR_erstellt]]\n[[Kategorie:RE:OCR_nicht_zugeschnitten]]"
+            "\n'''Rages''' s. {{Polytonisch|'Pάγα}} ta."
+            "\n{{Seite|128||{{REEL|I A,1|128}}}}\n[[Kategorie:RE:OCR_Seite_nicht_gefunden]]"
         )
         compare(expected, self.task.re_page.first_article.text.strip())
         expected = "'''Rages'''"
         compare(expected, self.task.re_page.splitted_article_list[2][0].text.strip())
+
+    def _placeholder_page(self, article_text: str) -> RePage:
+        page_mock = PageMock()
+        page_mock.title_str = "RE:Rages"
+        page_mock.text = (
+            "{{REDaten|BAND=I A,1|SPALTE_START=127|SPALTE_END=OFF|KORREKTURSTAND=Unvollständig}}"
+            f"{article_text}{{{{REAutor|OFF}}}}"
+        )
+        return RePage(page_mock)
+
+    def test_task_skips_page_flagged_for_stammdaten_check(self):
+        self.put_page_to_cloud("I A,1_0127")
+        self.task.re_page = self._placeholder_page("'''Rages'''[[Kategorie:RE:Stammdaten überprüfen]]")
+        self.assertTrue(self.task.task())
+        compare("'''Rages'''[[Kategorie:RE:Stammdaten überprüfen]]", self.task.re_page.first_article.text.strip())
+
+    def test_task_skips_article_that_has_ocr_already(self):
+        self.put_page_to_cloud("I A,1_0127")
+        self.task.re_page = self._placeholder_page("'''Rages'''[[Kategorie:RE:OCR_erstellt]]")
+        self.assertTrue(self.task.task())
+        compare("'''Rages'''[[Kategorie:RE:OCR_erstellt]]", self.task.re_page.first_article.text.strip())
+
+    def test_task_stops_when_the_run_limit_is_reached(self):
+        self.put_page_to_cloud("I A,1_0127")
+        self.task.counter = 9
+        self.task.re_page = self._placeholder_page("'''Rages'''")
+        self.assertTrue(self.task.task())
+        compare("'''Rages'''", self.task.re_page.first_article.text.strip())
+
+    def test_get_raw_page_reraises_unexpected_client_error(self):
+        error = ClientError({"Error": {"Code": "AccessDenied"}}, "GetObject")
+        with mock.patch.object(self.task.s3_client, "get_object", side_effect=error), self.assertRaises(ClientError):
+            self.task.get_raw_page("I A,1_0127")

--- a/service/ws_re/scanner/tasks/test_data/create_ocr/test_get_text_for_article.yml
+++ b/service/ws_re/scanner/tasks/test_data/create_ocr/test_get_text_for_article.yml
@@ -6,6 +6,7 @@ single_page_article:
     title: Ragando
   expect: |
     [[Kategorie:RE:OCR_erstellt]]
+    [[Kategorie:RE:OCR_nicht_zugeschnitten]]
     '''Ragando,''' ein Ort in [[RE:Noricum|Noricum]], nach {{RE siehe|Itinerarien|Itin.}} Ant. 129 ([[RE:Abi|Abi]].) ''Ragundone'', nach [[RE:Tabula Peutingeriana|Tab. Peut.]] ''Ragandone'', nach Itin. Hieros. 560 ''Ragindone'', in der Mitte zwischen [[RE:Celeia|Celeia]] (Cilli) und {{RE siehe|Poetovio}} (Pettau) gelegen, nach Itin. Ant. und Tab. Peut. je 18, nach Itin. Hieros. (auf Umwegen) je 24 röm. Meilen von beiden Städten entfernt, also im südöstlichen Steiermark, nach CIL III p. 645<ref name="CIL 3p|645">[https://cil.bbaw.de/hauptnavigation/das-cil/baende CORPUS INSCRIPTIONUM LATINARUM I{{sup|2}} ff.] 645</ref> bei Loßnitz, nach der angehängten {{SperrSchrift|Kiepert}} sehen Karte bei Studenitz.
 full_blown_example:
   given:
@@ -15,16 +16,17 @@ full_blown_example:
     title: Rauchopfer
   expect: |
     [[Kategorie:RE:OCR_erstellt]]
+    [[Kategorie:RE:OCR_nicht_zugeschnitten]]
     '''Rauchopfer.'''
 
     I. Begriffsbestimmung.
 
     Als R. sind diejenigen Brandopfer zu fassen, 40 welche um des Geruches willen dargebracht werden, die also im wesentlichen durch Verbrennung erzeugte Geruchsopfer sind. So umschreibt den Begriff auch die Liste bei [[RE:Iulius 398|Pollux]] I 26: {{Polytonisch|λιβανωτὸν καθαγίζειν, Φυμιαν, ἀρώματα λύειν ἐν πυρί. τὰ δὲ ἀρώματα καὶ θυμιάματα καλείται}}. Der letzte Satz ist zwar nicht richtig, da der Begriff {{Polytonisch|θυμιάματα}} nur eine Unterabteilung der {{Polytonisch|ἀρώματα}} sind, wie auch aus {{RE siehe|Theophrastos 3|Theophr.}} de odor. 12f. zu entnehmen ist: Manche Stoffe geben nur bei der 50 Verbrennung einen Geruch von sich, so {{Polytonisch|ἡ [[RE:Smyrna 3|σμύρνα]] καὶ ὁ λιβανωτὸς καὶ {{RE siehe|Pan|παν}} τὸ Φνμιατόν}}. Diese Stoffe haben wegen ihrer dichteren Natur die {{Polytonisch|πύρωοις}} nötig, um zu duften. Doch darf bei einer Betrachtung der R. auch das Gegenstück nicht außer acht gelassen werden, diejenigen Räucherungen, bei denen die Verbrennung zur Erzeugung übler Gerüche dient. Ferner muß auch kurz die im häuslichen [[RE:Leben(a)|Leben]] zur Erzielung von Wohlgerüchen angewandte Räucherung ge- 60 streift werden, da aus ihr heraus die R. selbst erwachsen sind und sie in der Geschichte des Handels mit ausländischen Spezereien, die zu R. gebraucht werden, eine Rolle spielt. Denn wie die Menschen, so lieben auch die Götter, schon im Glauben der homerischen Zeit, den Wohlgeruch. Die Annehmlichkeit des Geruchs, den die Menschen schätzen, will man auch den
-    {{Seite|268}}
+    {{Seite|268||{{REEL|I A,1|268}}}}
     1
     {{Seite|269||{{REEL|I A,1|269}}}}
     2
-    {{Seite|270}}
+    {{Seite|270||{{REEL|I A,1|270}}}}
     3
     {{Seite|271||{{REEL|I A,1|271}}}}
     [[RE:Raudii campi|Raudii campi]]

--- a/service/ws_re/scanner/tasks/test_death_re_links.py
+++ b/service/ws_re/scanner/tasks/test_death_re_links.py
@@ -2,7 +2,7 @@
 from unittest import mock
 
 from ddt import ddt, file_data
-from testfixtures import compare
+from testfixtures import LogCapture, compare
 
 from service.ws_re.scanner.tasks.death_re_links import DEALTask
 from service.ws_re.scanner.tasks.test_base_task import TaskTestCase
@@ -48,6 +48,24 @@ class TestDEALTask(TaskTestCase):
             task = DEALTask(None, self.logger)
             compare({"success": True, "changed": False}, task.run(re_page))
             compare(expect, task.data)
+
+    def test_process_stops_after_50_links_in_the_text(self):
+        with mock.patch(BASE_TASK_PYWIKIBOT_PAGE, new_callable=mock.MagicMock) as page_mock:
+            links = "".join(f"[[RE:Aal {idx}]]" for idx in range(60))
+            self.page_mock.text = f"{{{{REDaten\n|KORREKTURSTAND=fertig\n}}}}\n{links}\n{{{{REAutor|Autor.}}}}"
+            self.page_mock.title_str = "Re:Title"
+            page_mock.return_value.exists.return_value = False
+            re_page = RePage(self.page_mock)
+            task = DEALTask(None, self.logger)
+            compare({"success": True, "changed": False}, task.run(re_page))
+            compare(51, len(task.data))
+
+    def test_finish_task(self):
+        task = DEALTask(None, self.logger)
+        with mock.patch.object(DEALTask, "report_data_entries") as report_mock, LogCapture() as log_catcher:
+            task.finish_task()
+        report_mock.assert_called_once_with()
+        log_catcher.check_present(("Test", "INFO", "closing task DEAL"))
 
     def test_build_entries(self):
         task = DEALTask(None, self.logger)

--- a/service/ws_re/scanner/tasks/test_death_wp_links.py
+++ b/service/ws_re/scanner/tasks/test_death_wp_links.py
@@ -2,7 +2,7 @@
 from unittest import mock
 
 import pywikibot
-from testfixtures import compare
+from testfixtures import LogCapture, compare
 
 from service.ws_re.scanner.tasks.death_wp_links import DEWPTask
 from service.ws_re.scanner.tasks.test_base_task import TaskTestCase
@@ -147,6 +147,13 @@ class TestDEWPTask(TaskTestCase):
         self.assertTrue(task._data_exists())
         task.data = {"not_exists": [], "redirect": [], "disambiguous": []}
         self.assertFalse(task._data_exists())
+
+    def test_finish_task(self):
+        task = DEWPTask(None, self.logger)
+        with mock.patch.object(DEWPTask, "report_data_entries") as report_mock, LogCapture() as log_catcher:
+            task.finish_task()
+        report_mock.assert_called_once_with()
+        log_catcher.check_present(("Test", "INFO", "closing task DEWP"))
 
     def test_bug_invalid_title(self):
         with mock.patch(_BASE_TASK_PYWIKIBOT_PAGE, new_callable=mock.MagicMock) as page_mock:

--- a/service/ws_re/scanner/tasks/test_register_scanner.py
+++ b/service/ws_re/scanner/tasks/test_register_scanner.py
@@ -277,6 +277,75 @@ text.
                 ("Test", "ERROR", StringComparison("No available Lemma in Registers for issue I,1 .* Reason is:.*")),
             )
 
+    def test_fetch_wd_link_no_item(self):
+        with mock.patch.object(SCANTask, "_get_target_from_wd", mock.Mock(return_value=None)):
+            compare(({}, ["wd_link"]), self.task._fetch_wd_link(None))
+
+    def test_get_link_from_wd_without_sitelink(self):
+        target = mock.Mock()
+        target.getSitelink.side_effect = pywikibot.exceptions.NoSiteLinkError(mock.MagicMock(), "dewiki")
+        with (
+            mock.patch.object(SCANTask, "_get_target_from_wd", mock.Mock(return_value=target)),
+            mock.patch.object(SCANTask, "_get_site_from_str", mock.Mock()),
+        ):
+            compare(None, self.task._get_link_from_wd("wikipedia"))
+
+    def test_get_target_from_wd_without_data_item(self):
+        self.page_mock.data_item.side_effect = pywikibot.exceptions.NoPageError(mock.MagicMock())
+        self.page_mock.text = "{{REDaten|BAND=I,1}}\ntext.\n{{REAutor|OFF}}"
+        self.task.re_page = RePage(self.page_mock)
+        compare(None, self.task._get_target_from_wd())
+
+    def test_fetch_pages_construction_too_complex(self):
+        self.page_mock.title_str = "RE:Aal"
+        self.page_mock.text = """{{REDaten
+|BAND=I,1
+|SPALTE_START=1
+}}
+text.
+{{REAutor|Abel.}}
+{{REDaten
+|BAND=I,1
+|SPALTE_START=1
+}}
+text.
+{{REAutor|Abel.}}"""
+        self.task.re_page = RePage(self.page_mock)
+        article_list = list(self.task.re_page.splitted_article_list[0]) + list(
+            self.task.re_page.splitted_article_list[1]
+        )
+        with (
+            mock.patch.object(type(self.task.re_page), "complex_construction", True),
+            LogCapture() as log_catcher,
+        ):
+            compare(({}, []), self.task._fetch_pages(article_list))
+            log_catcher.check(("Test", "ERROR", "The construct of [[RE:Aal|Aal]] is too complex, can't analyse."))
+
+    def test_finish_task(self):
+        self.task._strategies = {"update_lemma_by_name": ["Aal"], "update_lemma_by_sortkey": ["Aas"]}
+        with (
+            mock.patch(
+                "service.ws_re.scanner.tasks.register_scanner.AuthorCrawler.get_author_mapping",
+                mock.Mock(return_value={}),
+            ),
+            mock.patch(
+                "service.ws_re.scanner.tasks.register_scanner.AuthorCrawler.process_author_infos",
+                mock.Mock(return_value={}),
+            ),
+            LogCapture() as log_catcher,
+        ):
+            self.task.finish_task()
+        log_catcher.check_present(
+            ("Test", "INFO", "STRATEGY_update_lemma_by_name: 1"),
+            ("Test", "INFO", "STRATEGY_update_lemma_by_sortkey: 1"),
+            ("Test", "INFO", "['Aas']"),
+            ("Test", "INFO", "Fetch changes for the authors."),
+            ("Test", "INFO", "Persist the author data."),
+            ("Test", "INFO", "Persist the register data."),
+            ("Test", "INFO", "Push changes for authors and registers."),
+            order_matters=True,
+        )
+
     @real_wiki_test
     def test_get_wd_sitelink(self):
         WS_WIKI = pywikibot.Site(code="de", fam="wikisource", user="THEbotIT")

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_claim_factory.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_claim_factory.py
@@ -20,7 +20,7 @@ class BaseTestClaimFactory(TestCase):
         if REAL_WIKI_TEST:
             self.wikisource_site = pywikibot.Site(code="de", fam="wikisource", user="THEbotIT")
             self.wikidata_site = self.wikisource_site.data_repository()
-        else:
+        else:  # pragma: no cover - only taken in the plain unittest run, coverage is measured against the wiki
             self.wikidata_site = MagicMock()
             self.wikisource_site = MagicMock()
         self.logger = WikiLogger(bot_name="Test", start_time=datetime(2000, 1, 1), log_to_screen=False)
@@ -67,6 +67,20 @@ class TestClaimFactory(BaseTestClaimFactory):
 
     def test_property_string(self):
         compare("P1234", self.P1234FactoryDummy.get_property_string())
+
+    def test_property_string_of_a_class_without_property(self):
+        class NoPropertyFactory(ClaimFactory):
+            pass
+
+        with self.assertRaises(ValueError):
+            NoPropertyFactory.get_property_string()
+
+    def test_get_claim_json_of_the_base_factory_is_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            ClaimFactory(MagicMock(), self.logger)._get_claim_json()
+
+    def test_get_claim_json_of_the_dummy_is_empty(self):
+        compare([], self.factory_dummy._get_claim_json())
 
     def test__filter_new_vs_old_claim_list(self):
         compare(

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p13269_directs_reader_to.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p13269_directs_reader_to.py
@@ -1,6 +1,8 @@
 # pylint: disable=protected-access
+from unittest import mock
+
 import pywikibot
-from testfixtures import compare
+from testfixtures import LogCapture, StringComparison, compare
 
 from service.ws_re.scanner.tasks.wikidata.claims.p13269_directs_readers_to import P13269DirectsReadersTo
 from service.ws_re.scanner.tasks.wikidata.claims.test_claim_factory import BaseTestClaimFactory
@@ -10,6 +12,19 @@ from tools.test import real_wiki_test
 
 @real_wiki_test
 class TestP13269DirectsReadersTo(BaseTestClaimFactory):
+    def test__get_claim_json_target_page_without_data_item(self):
+        re_page = RePage(pywikibot.Page(self.wikisource_site, "RE:Amantes 2"))
+        factory = P13269DirectsReadersTo(re_page, self.logger)
+        with (
+            mock.patch(
+                "service.ws_re.scanner.tasks.wikidata.claims.p13269_directs_readers_to.pywikibot.Page.data_item",
+                mock.Mock(side_effect=pywikibot.exceptions.NoPageError(mock.MagicMock())),
+            ),
+            LogCapture() as log_catcher,
+        ):
+            compare([], factory._get_claim_json())
+        log_catcher.check_present(("Test", "ERROR", StringComparison("P13269: Page existed for .*, but no data item.")))
+
     def test__get_claim_json_no_redirect(self):
         re_page = self._create_mock_page(text="{{REDaten}}\ntext\n{{REAutor|Some Author.}}", title="RE:Bla")
         factory = P13269DirectsReadersTo(re_page, self.logger)

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p1343_described_by_source.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p1343_described_by_source.py
@@ -1,6 +1,8 @@
 # pylint: disable=protected-access
+from unittest import mock
+
 import pywikibot
-from testfixtures import compare
+from testfixtures import LogCapture, StringComparison, compare
 
 from service.ws_re.scanner.tasks.wikidata.claims._base import SnakParameter
 from service.ws_re.scanner.tasks.wikidata.claims.claim_factory import ClaimFactory
@@ -12,6 +14,29 @@ from tools.test import real_wiki_test
 
 @real_wiki_test
 class TestP1343DescribedBySource(BaseTestClaimFactory):
+    def test__get_claim_json_without_valid_qualifiers(self):
+        re_page = RePage(pywikibot.Page(self.wikisource_site, "RE:Aal"))
+        factory = P1343DescribedBySource(re_page, self.logger)
+        with mock.patch.object(factory, "get_qualifiers", mock.Mock(return_value=[])):
+            compare([], factory._get_claim_json())
+
+    def test_existing_qualifier_of_a_claim_without_p805(self):
+        re_page = RePage(pywikibot.Page(self.wikisource_site, "RE:Aal"))
+        factory = P1343DescribedBySource(re_page, self.logger)
+        claim = mock.MagicMock()
+        claim.toJSON.return_value = {"mainsnak": {"datavalue": {"value": {"numeric-id": 1138524}}}}
+        target_item = mock.MagicMock(id="Q4711")
+        target_item.get.return_value = {"claims": {"P1343": [claim]}}
+        with LogCapture() as log_catcher:
+            compare([], factory.get_existing_qualifiers(target_item))
+        log_catcher.check_present(
+            (
+                "Test",
+                "WARNING",
+                StringComparison(".*doesn't have P805 to specify the claim P1343. This entry was wiped."),
+            )
+        )
+
     def test__get_claim_json(self):
         re_page = RePage(pywikibot.Page(self.wikisource_site, "RE:Aal"))
         factory = P1343DescribedBySource(re_page, self.logger)

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p155_follows_p156_followed_by.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p155_follows_p156_followed_by.py
@@ -1,13 +1,24 @@
 # pylint: disable=protected-access
+from unittest.mock import MagicMock
+
 from testfixtures import compare
 
-from service.ws_re.scanner.tasks.wikidata.claims.p155_follows_p156_followed_by import P155Follows, P156FollowedBy
+from service.ws_re.scanner.tasks.wikidata.claims.p155_follows_p156_followed_by import (
+    Neighbour,
+    P155Follows,
+    P156FollowedBy,
+)
 from service.ws_re.scanner.tasks.wikidata.claims.test_claim_factory import BaseTestClaimFactory
 from tools.test import real_wiki_test
 
 
 @real_wiki_test
 class TestNeighbours(BaseTestClaimFactory):
+    def test_neighbour_of_the_base_class_is_not_implemented(self):
+        factory = Neighbour(MagicMock(), self.logger)
+        with self.assertRaises(NotImplementedError):
+            _ = factory.neighbour
+
     def test__get_claim_json_no_follows_exists(self):
         re_page = self._create_mock_page(text="{{REDaten\n|VORGÄNGER=OFF}}\ntext\n{{REAutor|Blub}}", title="RE:Bla")
         factory = P155Follows(re_page, self.logger)

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p31_instance_of.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p31_instance_of.py
@@ -20,3 +20,19 @@ class TestP31InstanceOf(BaseTestClaimFactory):
         factory = P31InstanceOf(re_page, None)
         claim_json = factory._get_claim_json()
         compare(1302249, claim_json[0]["mainsnak"]["datavalue"]["value"]["numeric-id"])
+
+    def test__get_claim_json_index(self):
+        re_page = self._create_mock_page(
+            text="{{REDaten}}\ntext\n{{REAutor|Some Author.}}", title="RE:Register (Band XI)"
+        )
+        factory = P31InstanceOf(re_page, None)
+        claim_json = factory._get_claim_json()
+        compare(873506, claim_json[0]["mainsnak"]["datavalue"]["value"]["numeric-id"])
+
+    def test__get_claim_json_prologue(self):
+        re_page = self._create_mock_page(
+            text="{{REDaten}}\ntext\n{{REAutor|Some Author.}}", title="RE:Vorwort (Band I)"
+        )
+        factory = P31InstanceOf(re_page, None)
+        claim_json = factory._get_claim_json()
+        compare(920285, claim_json[0]["mainsnak"]["datavalue"]["value"]["numeric-id"])

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p50_author.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p50_author.py
@@ -1,4 +1,7 @@
 # pylint: disable=protected-access
+from unittest import mock
+
+import pywikibot
 from testfixtures import compare
 
 from service.ws_re.scanner.tasks.wikidata.claims.p50_author import P50Author
@@ -8,6 +11,15 @@ from tools.test import real_wiki_test
 
 @real_wiki_test
 class TestP50Author(BaseTestClaimFactory):
+    def test__get_claim_json_author_lemma_has_no_data_item(self):
+        re_page = self._create_mock_page(text="{{REDaten}}\ntext\n{{REAutor|Wagner.}}", title="RE:Bla")
+        factory = P50Author(re_page, self.logger)
+        with mock.patch(
+            "service.ws_re.scanner.tasks.wikidata.claims.p50_author.pywikibot.Page.data_item",
+            mock.Mock(side_effect=pywikibot.exceptions.NoPageError(mock.MagicMock())),
+        ):
+            compare(0, len(factory._get_claim_json()))
+
     def test__get_claim_json_no_author_available(self):
         re_page = self._create_mock_page(text="{{REDaten}}\ntext\n{{REAutor|Blub}}", title="RE:Bla")
         factory = P50Author(re_page, self.logger)

--- a/service/ws_re/scanner/tasks/wikidata/claims/test_p6216_copyright_status.py
+++ b/service/ws_re/scanner/tasks/wikidata/claims/test_p6216_copyright_status.py
@@ -1,8 +1,10 @@
 # pylint: disable=protected-access
 from typing import Any, ClassVar
+from unittest import mock
 
 from testfixtures import compare
 
+from service.ws_re.register.author import Author
 from service.ws_re.scanner.tasks.wikidata.claims.p6216_copyright_status import P6216CopyrightStatus
 from service.ws_re.scanner.tasks.wikidata.claims.test_claim_factory import BaseTestClaimFactory
 from tools.test import real_wiki_test
@@ -155,6 +157,13 @@ class TestP6216CopyrightStatus(BaseTestClaimFactory):
         factory = P6216CopyrightStatus(re_page, self.logger)
         claim_boethius = factory.min_years_since_death
         compare(None, claim_boethius)
+
+    def test_min_years_since_death_author_without_death_year(self):
+        # an author without a death year has to be treated as if they died this year
+        re_page = self._create_mock_page(text="{{REDaten|BAND=II,2}}\ntext\n{{REAutor|Boethius}}", title="RE:Bla")
+        factory = P6216CopyrightStatus(re_page, self.logger)
+        with mock.patch.object(factory, "get_authors_article", mock.Mock(return_value=[Author("Anonymous", {})])):
+            compare(None, factory.min_years_since_death)
 
     def test_min_years_since_death_author_not_known(self):
         re_page = self._create_mock_page(text="{{REDaten|BAND=II,2}}\ntext\n{{REAutor|Blablub}}", title="RE:Bla")

--- a/service/ws_re/scanner/tasks/wikidata/test_task.py
+++ b/service/ws_re/scanner/tasks/wikidata/test_task.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest import TestCase, mock, skip
 
 import pywikibot
-from testfixtures import compare
+from testfixtures import LogCapture, StringComparison, compare
 
 from service.ws_re.scanner.tasks.wikidata.claims._base import SnakParameter
 from service.ws_re.scanner.tasks.wikidata.claims._typing import JsonClaimDict
@@ -56,6 +56,62 @@ class TestDATATask(TestCase):
 
         def labels_and_sitelinks_has_changed(self, _) -> bool:
             return True
+
+    def test_back_link_main_topic_without_a_main_topic(self):
+        with (
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.pywikibot.Site"),
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.P1343DescribedBySource") as factory_mock,
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.ItemPage") as item_page_mock,
+        ):
+            factory_mock.return_value.get_main_topic_id.return_value = None
+            task = DATATask(None, WikiLogger(bot_name="Test", start_time=datetime(2000, 1, 1), log_to_screen=False))
+            task.re_page = mock.MagicMock()
+            task.back_link_main_topic()
+        item_page_mock.assert_not_called()
+
+    def test_back_link_main_topic_adds_and_removes_the_reference(self):
+        claim = mock.MagicMock()
+        with (
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.pywikibot.Site"),
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.P1343DescribedBySource") as factory_mock,
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.ItemPage") as item_page_mock,
+        ):
+            factory_mock.return_value.get_main_topic_id.return_value = 42
+            factory_mock.return_value.get_claims_to_update.return_value = {
+                "add": {"P1343": [claim]},
+                "remove": [claim],
+            }
+            task = DATATask(None, WikiLogger(bot_name="Test", start_time=datetime(2000, 1, 1), log_to_screen=False))
+            task.re_page = mock.MagicMock()
+            task.back_link_main_topic()
+        compare("Q42", item_page_mock.call_args[0][1])
+        item_page_mock.return_value.editEntity.assert_called_once_with(
+            data={"claims": {"P1343": [claim.toJSON.return_value]}}, summary="Add reference to a lexicon article."
+        )
+        item_page_mock.return_value.removeClaims.assert_called_once_with(
+            claims=[claim], summary="Remove old reference to a lexicon article."
+        )
+
+    def test_task_warns_when_the_backlink_target_is_a_redirect(self):
+        redirect_error = pywikibot.exceptions.IsRedirectPageError(mock.MagicMock())
+        with (
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.pywikibot.Site"),
+            mock.patch("service.ws_re.scanner.tasks.wikidata.task.NonClaims") as non_claims_mock,
+            mock.patch.object(DATATask, "_get_claimes_to_change", mock.Mock(return_value={"add": {}, "remove": []})),
+            mock.patch.object(DATATask, "back_link_main_topic", mock.Mock(side_effect=redirect_error)),
+            LogCapture() as log_catcher,
+        ):
+            non_claims_mock.return_value.labels_and_sitelinks_has_changed.return_value = False
+            task = DATATask(None, WikiLogger(bot_name="Test", start_time=datetime(2000, 1, 1), log_to_screen=False))
+            task.re_page = mock.MagicMock()
+            task.task()
+        log_catcher.check_present(
+            (
+                "Test",
+                "WARNING",
+                StringComparison("Backlink to main topic failed for .*, because target is a redirect."),
+            )
+        )
 
     @real_wiki_test
     def test_integration(self):
@@ -142,7 +198,7 @@ class TestDATATask(TestCase):
 
     @skip("For debuging.")
     @real_wiki_test
-    def test_debug(self):
+    def test_debug(self):  # pragma: no cover
         WS_WIKI = pywikibot.Site(code="de", fam="wikisource", user="THEbotIT")
         lemma = RePage(pywikibot.Page(WS_WIKI, "RE:Menephron 1"))
         data_task = DATATask(

--- a/service/ws_re/scanner/test_scanner.py
+++ b/service/ws_re/scanner/test_scanner.py
@@ -1,10 +1,10 @@
 # pylint: disable=protected-access
 from contextlib import suppress
 from datetime import datetime
-from unittest import mock, skip
+from unittest import mock
 
-from freezegun import freeze_time
-from testfixtures import LogCapture
+import pywikibot
+from testfixtures import LogCapture, compare
 
 from service.ws_re.scanner.base import ReScanner
 from service.ws_re.scanner.tasks.base_task import ReScannerTask
@@ -89,6 +89,8 @@ class TestReScanner(TestCloudBase):
         self.page_mock = page_patcher.start()
         self.page_error_mock = page_patcher_error.start()
         self.re_page_mock = re_page_patcher.start()
+        # both page patchers point at the same pywikibot.Page attribute, so the last one started wins
+        self.page_error_mock.return_value.isRedirectPage.return_value = False
 
     def _mock_task(self):
         # pylint: disable=attribute-defined-outside-init
@@ -286,63 +288,41 @@ class TestReScanner(TestCloudBase):
             )
             log_catcher.check_present(*expected_logging, order_matters=True)
 
-    @skip("I quit this task for the moment")
     def test_save_going_wrong(self):
         self._mock_surroundings()
-
-        def side_effect(*args, **kwargs):
-            raise ReDatenException(args, kwargs)
-
-        save_mock = mock.patch("service.ws_re.scanner.RePage.save", new_callable=mock.Mock()).start()
-        type(self.re_page_mock).save = save_mock.start()
-        save_mock.side_effect = side_effect
+        self.re_page_mock.return_value.save.side_effect = ReDatenException("no save possible")
         self.lemma_mock.return_value = [":RE:Lemma1"]
         with LogCapture() as log_catcher, ReScanner(log_to_screen=False, log_to_wiki=False, debug=False) as bot:
             log_catcher.clear()
             bot.tasks = [self.ONE1Task]
             bot.run()
             expected_logging = (
-                ("ReScanner", "INFO", "Process [https://de.wikisource.org/wiki/:RE:Lemma1 :RE:Lemma1]"),
+                ("ReScanner", "DEBUG", "Process [https://de.wikisource.org/wiki/:RE:Lemma1 :RE:Lemma1]"),
                 ("ReScanner", "INFO", "I"),
-                ("ReScanner", "INFO", "ReScanner hat folgende Aufgaben bearbeitet: BASE"),
+                ("ReScanner", "DEBUG", "ReScanner hat folgende Aufgaben bearbeitet: BASE"),
                 ("ReScanner", "ERROR", "RePage can't be saved."),
             )
             log_catcher.check_present(*expected_logging, order_matters=True)
 
-    class WAITTask(ReScannerTask):
-        def task(self):
-            pass
-
-    @skip("skipped after changing to CloudBot")
-    @freeze_time("Jan 14th, 2020", auto_tick_seconds=1)
-    def test_lemma_processed_are_saved(self):
+    def test_lemma_creation_runs_into_api_timeout(self):
         self._mock_surroundings()
-        self.lemma_mock.return_value = [":RE:Lemma0", ":RE:Lemma1", ":RE:Lemma2"]
-        self.re_page_mock.side_effect = [ReDatenException, mock.DEFAULT, mock.DEFAULT, mock.DEFAULT, mock.DEFAULT]
-        bot = ReScanner(log_to_screen=False, log_to_wiki=False)
-        bot.tasks = [self.WAITTask]
-        with bot:
+        self.lemma_mock.return_value = [":RE:Lemma1", ":RE:Lemma2"]
+        self.re_page_mock.side_effect = [pywikibot.exceptions.ApiTimeoutError("too slow"), mock.DEFAULT]
+        with LogCapture() as log_catcher, ReScanner(log_to_screen=False, log_to_wiki=False, debug=False) as bot:
+            log_catcher.clear()
+            bot.tasks = [self.ONE1Task]
             bot.run()
-        # with open(bot.data.data_folder + os.sep + "ReScanner.data.json", encoding="utf-8") as data_file:
-        #     data = json.load(data_file)
-        #     self.assertEqual({":RE:Lemma1": mock.ANY, ":RE:Lemma2": mock.ANY},
-        #                      data)
-        #     self.assertLessEqual(datetime.strptime(data[":RE:Lemma1"], "%Y%m%d%H%M%S"),
-        #                          datetime.strptime(data[":RE:Lemma2"], "%Y%m%d%H%M%S"))
-        self.lemma_mock.return_value = [":RE:Lemma3", ":RE:Lemma4"]
-        with bot:
-            bot.run()
-        # with open(bot.data.data_folder + os.sep + "ReScanner.data.json", encoding="utf-8") as data_file:
-        #     data = json.load(data_file)
-        #     self.assertEqual({":RE:Lemma1": mock.ANY, ":RE:Lemma2": mock.ANY,
-        #                       ":RE:Lemma3": mock.ANY, ":RE:Lemma4": mock.ANY},
-        #                      data)
-        #     self.assertLess(datetime.strptime(data[":RE:Lemma1"], "%Y%m%d%H%M%S"),
-        #                     datetime.strptime(data[":RE:Lemma2"], "%Y%m%d%H%M%S"))
-        #     self.assertLess(datetime.strptime(data[":RE:Lemma2"], "%Y%m%d%H%M%S"),
-        #                     datetime.strptime(data[":RE:Lemma3"], "%Y%m%d%H%M%S"))
-        #     self.assertLess(datetime.strptime(data[":RE:Lemma3"], "%Y%m%d%H%M%S"),
-        #                     datetime.strptime(data[":RE:Lemma4"], "%Y%m%d%H%M%S"))
+            expected_logging = (
+                ("ReScanner", "ERROR", "Timeout at lemma (:RE:Lemma1) creation"),
+                ("ReScanner", "DEBUG", "Process [https://de.wikisource.org/wiki/:RE:Lemma2 :RE:Lemma2]"),
+            )
+            log_catcher.check_present(*expected_logging, order_matters=True)
+
+    def test_lemma_list(self):
+        self.petscan_mock.return_value = ([":RE:Lemma1", ":RE:Lemma2"], 2)
+        with ReScanner(log_to_screen=False, log_to_wiki=False, debug=False) as bot:
+            compare([":RE:Lemma1", ":RE:Lemma2"], bot.lemma_list)
+        self.petscan_mock.assert_called_once_with(mock.ANY, timeframe=72)
 
     def test_reload_deprecated_lemma_data_none_there(self):
         self._mock_surroundings()
@@ -359,21 +339,3 @@ class TestReScanner(TestCloudBase):
                 ("ReScanner", "WARNING", "There isn't deprecated data to reload."),
             )
             log_catcher.check_present(*expected_logging, order_matters=True)
-
-    @skip("skipped after changing to CloudBot")
-    def test_reload_deprecated_lemma_data(self):
-        self._mock_surroundings()
-        self.lemma_mock.return_value = [":RE:Lemma1"]
-        # with open(_DATA_PATH_TEST + os.sep + "ReScanner.data.json.deprecated", mode="w", encoding="utf-8") \
-        #         as persist_json:
-        #     json.dump({":RE:Lemma1": "20000101000000"}, persist_json)
-        with (
-            suppress(AssertionError),
-            LogCapture() as log_catcher,
-            ReScanner(log_to_screen=False, log_to_wiki=False, debug=False),
-        ):
-            log_catcher.check(
-                ("ReScanner", "INFO", "Start the bot ReScanner."),
-                ("ReScanner", "WARNING", "The last run wasn't successful. The data is thrown away."),
-                ("ReScanner", "WARNING", "Try to get the deprecated data back."),
-            )

--- a/service/ws_re/template/test_article.py
+++ b/service/ws_re/template/test_article.py
@@ -1,12 +1,13 @@
 # pylint: disable=no-self-use,protected-access
 from datetime import datetime
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from testfixtures import compare
 
 from service.ws_re.template import ARTICLE_TEMPLATE, ReDatenException
 from service.ws_re.template.article import Article
 from service.ws_re.template.re_author import REAuthor
+from tools.template_handler import TemplateHandlerException
 
 
 class TestReArticle(TestCase):
@@ -177,6 +178,13 @@ class TestReArticle(TestCase):
             ReDatenException, "Article has the wrong structure. There is text after the article."
         ):
             Article.from_text(article_text)
+
+    def test_from_text_author_template_with_wrong_structure(self):
+        with (
+            mock.patch.object(REAuthor, "from_template", mock.Mock(side_effect=TemplateHandlerException("no title"))),
+            self.assertRaisesRegex(ReDatenException, "Author-Template has the wrong structure."),
+        ):
+            Article.from_text("{{REDaten}}\ntext\n{{REAutor|Some Author.}}")
 
     def test_from_text_bug_bad_whitespace(self):
         article_text = "{{REDaten \n|BAND=I,1}}\ntext\n{{REAutor|Some Author.}}"

--- a/tools/bots/test_base.py
+++ b/tools/bots/test_base.py
@@ -1,11 +1,13 @@
 # pylint: disable=protected-access,no-member,no-self-use
+import os
 import typing
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import boto3
 from moto import mock_aws
+from testfixtures import compare
 
-from tools.bots.base import is_aws_test_env
+from tools.bots.base import get_aws_credentials, is_aws_test_env
 
 JSON_TEST = '{\n  "data": {\n    "a": [\n      1,\n      2\n    ]\n  },\n  "time": "2020-01-14 00:00:00"\n}'
 JSON_TEST_EXTEND = (
@@ -15,6 +17,24 @@ DATA_TEST = {"data": {"a": [1, 2]}, "time": "2020-01-14 00:00:00"}
 DATA_TEST_EXTEND = {"data": {"a": [1, 2], "b": 2}, "time": "2020-01-14 00:00:00"}
 BUCKET_NAME = f"wiki-bots-persisted-data-{'tst' if is_aws_test_env() else 'prd'}"
 TABLE_NAME = f"wiki_bots_manage_table_{'tst' if is_aws_test_env() else 'prd'}"
+
+
+class TestAwsCredentials(TestCase):
+    def test_credentials_of_the_test_environment(self):
+        test_env = {"WS_AWS_TST_ENV": "1", "WS_AWS_TST_KEY": "tst_key", "WS_AWS_TST_SECRET": "tst_secret"}
+        with mock.patch.dict(os.environ, test_env, clear=True):
+            compare(True, is_aws_test_env())
+            compare(("tst_key", "tst_secret"), get_aws_credentials())
+
+    def test_credentials_of_the_production_environment(self):
+        prd_env = {"WS_AWS_PRD_KEY": "prd_key", "WS_AWS_PRD_SECRET": "prd_secret"}
+        with mock.patch.dict(os.environ, prd_env, clear=True):
+            compare(False, is_aws_test_env())
+            compare(("prd_key", "prd_secret"), get_aws_credentials())
+
+    def test_credentials_without_any_environment(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            compare(("", ""), get_aws_credentials())
 
 
 class TestCloudBase(TestCase):

--- a/tools/bots/test_cloud_bot.py
+++ b/tools/bots/test_cloud_bot.py
@@ -169,13 +169,12 @@ class TestCloudBot(TestCloudBase):
         self._make_json_file(filename="DataOutdatedBot.data.json")
         StatusManager("DataOutdatedBot").finish_run(success=True)
         with (
-            suppress(AssertionError),
             LogCapture() as log_catcher,
             self.DataOutdatedBot(log_to_screen=False, log_to_wiki=False) as bot,
         ):
-            self.assertIn("DataOutdatedBot WARNING\n  The data is thrown away. It is out of date", str(log_catcher))
+            log_catcher.check_present(("DataOutdatedBot", "WARNING", "The data is thrown away. It is out of date"))
             self.assertDictEqual({}, bot.data._data)
-            bot.run()
+            self.assertTrue(bot.run())
 
     @freeze_time("2001-12-31", auto_tick_seconds=60)
     def test_data_outdated_not_outdated_1(self):

--- a/tools/bots/test_persisted_data.py
+++ b/tools/bots/test_persisted_data.py
@@ -1,6 +1,8 @@
 # pylint: disable=protected-access,no-member,no-self-use
 import json
+from unittest import mock
 
+from botocore.exceptions import ClientError
 from freezegun import freeze_time
 from testfixtures import compare
 
@@ -27,6 +29,11 @@ class TestPersistedData(TestCloudBase):
 
     def test_load_from_bucket_no_data(self):
         with self.assertRaises(BotException):
+            self.data.load()
+
+    def test_load_from_bucket_unexpected_client_error(self):
+        error = ClientError({"Error": {"Code": "AccessDenied"}}, "GetObject")
+        with mock.patch.object(self.data.s3_client, "get_object", side_effect=error), self.assertRaises(ClientError):
             self.data.load()
 
     def test_delete_key(self):

--- a/tools/test_abbyy_xml.py
+++ b/tools/test_abbyy_xml.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+
+from tools.abbyy_xml import AbbyyXML
+
+
+def _char_params(text: str) -> str:
+    return "".join(f"<charParams>{char}</charParams>" for char in text)
+
+
+def _line(text: str) -> str:
+    return f"<line><formatting>{_char_params(text)}</formatting></line>"
+
+
+def _paragraph(*lines: str) -> str:
+    return "<par>" + "".join(_line(line) for line in lines) + "</par>"
+
+
+def _block(*paragraphs: str) -> str:
+    return "<block><text>" + "".join(paragraphs) + "</text></block>"
+
+
+def _document(*blocks: str) -> str:
+    return '<?xml version="1.0" encoding="UTF-8"?><document><page>' + "".join(blocks) + "</page></document>"
+
+
+class TestAbbyyXML(TestCase):
+    def test_single_line(self):
+        reader = AbbyyXML(_document(_block(_paragraph("abc"))))
+        self.assertEqual("abc\n\n", reader.get_text())
+
+    def test_multiple_lines_in_one_paragraph(self):
+        reader = AbbyyXML(_document(_block(_paragraph("first", "second"))))
+        self.assertEqual("firstsecond\n\n", reader.get_text())
+
+    def test_multiple_paragraphs_and_blocks(self):
+        reader = AbbyyXML(_document(_block(_paragraph("a"), _paragraph("b")), _block(_paragraph("c"))))
+        self.assertEqual("a\nb\n\nc\n\n", reader.get_text())
+
+    def test_only_first_page_is_processed(self):
+        two_pages = (
+            '<?xml version="1.0" encoding="UTF-8"?><document>'
+            f"<page>{_block(_paragraph('one'))}</page>"
+            f"<page>{_block(_paragraph('two'))}</page>"
+            "</document>"
+        )
+        reader = AbbyyXML(two_pages)
+        self.assertEqual("one\n\n", reader.get_text())
+
+    def test_process_document_equals_get_text(self):
+        reader = AbbyyXML(_document(_block(_paragraph("xy"))))
+        self.assertEqual(reader.process_document(), reader.get_text())

--- a/tools/test_petscan.py
+++ b/tools/test_petscan.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar
 from unittest import TestCase, mock
 from unittest.mock import patch
 
+import requests
 import requests_mock
 from freezegun import freeze_time
 from testfixtures import compare
@@ -102,6 +103,23 @@ class TestPetScan(TestCase):
         self.assertDictEqual(
             {"edits[bots]": "yes", "edits[anons]": "no", "edits[flagged]": "yes"}, self.petscan.options
         )
+
+    def test_set_sort_criteria(self):
+        self.petscan.set_sort_criteria("date")
+        self.assertDictEqual({"sortby": "date"}, self.petscan.options)
+
+    def test_set_sort_criteria_invalid(self):
+        with self.assertRaises(PetScanException):
+            self.petscan.set_sort_criteria("not a criteria")
+
+    def test_run_with_a_broken_connection(self):
+        with requests_mock.mock() as request_mock:
+            request_mock.get(
+                "https://petscan.wmflabs.org/?language=de&project=wikisource&format=json&doit=1",
+                exc=requests.exceptions.ConnectTimeout,
+            )
+            with self.assertRaises(PetScanException):
+                self.petscan.run()
 
     def test_construct_cat_string(self):
         self.petscan.add_positive_category("pos 1")

--- a/tools/test_template_handler.py
+++ b/tools/test_template_handler.py
@@ -1,7 +1,7 @@
 # pylint: disable=protected-access,line-too-long
 from unittest import TestCase
 
-from tools.template_handler import TemplateHandler
+from tools.template_handler import TemplateHandler, TemplateHandlerException
 
 test_title = "vorlage"
 test_title_sperr = "Sperrsatz"
@@ -231,6 +231,10 @@ class TestTemplateHandler(TestCase):
         handler = TemplateHandler(test_string_bug)
         real_dict = handler.get_parameterlist()
         self.assertEqual(test_list_bug, real_dict)
+
+    def test_template_without_title(self):
+        with self.assertRaises(TemplateHandlerException):
+            TemplateHandler("{{|1=test1}}")
 
     def test_bug_poemlist(self):
         handler = TemplateHandler("{{SeitePR|[I] Schmutztitel|Mittelalterliches Hausbuch 1887 0001.jpg}}")


### PR DESCRIPTION
Brings project coverage from **96.62 %** to **99.93 %** (12607 statements, 9 missed), measured in the same mode CI's `wikitest` job reports to codecov.

Verified locally, all green:

| check | result |
| --- | --- |
| `pytest --cov=. service tools` with `WS_REAL_WIKI=1` | 974 passed, 12 skipped |
| `make unittest` (no `WS_REAL_*`) | 845 passed, 141 skipped |
| `ruff` / `ruff format --check` / `ty` | pass |

## What changed

**Coverage configuration**

- `service/ws_re/_update_items_in_volumes.py` joins the existing omit list for one-time offline scripts — it opens a wiki connection at import time and cannot be imported from a test.
- `service/ws_re/integration_test/*` is omitted too. Those 83 statements only execute in the nightly `WS_REAL_DATA` job and are collected-and-skipped in every other run, so they counted as permanently missed in the number codecov reports.
- Six `if __name__ == "__main__":` guards got the `# pragma: no cover` marker that five other guards in the code base already carry.

**Stale skipped tests revived**

- `test_create_ocr.py`: `test_get_text_for_article_single_page` and `test_task_appends_ocr_for_rages` were skipped and had drifted from current `COCRTask` behaviour in exactly two ways — the `RE:OCR_nicht_zugeschnitten` maintenance category is now emitted below the OCR category, and `{{Seite|N}}` markers carry the REEL scan link. **This is the spot worth a close look:** the expectations in `test_get_text_for_article.yml` were regenerated against current behaviour rather than hand-checked line by line. Both drifts are visible in `create_ocr.py` (the `_cut_category` prefix and the `{{Seite|…||{{REEL|…}}}}` template).
- `test_scanner.py`: `test_save_going_wrong` revived, which covers the `RePage can't be saved.` error path in `scanner/base.py`.
- Two permanently skipped tests in `test_scanner.py` are removed (`test_lemma_processed_are_saved`, `test_reload_deprecated_lemma_data`) — their assertions were entirely commented out, so they asserted nothing.

**New tests**

`abbyy_xml.py` and `list_bot.py` had no dedicated test module at all and now have one. `gl/status.py` (27 % → 100 %), `create_ocr.py` (69 % → 100 %), `register_scanner.py` (91 % → 100 %), `scanner/base.py`, `wikidata/task.py` and the complete `wikidata/claims/` tree reach full coverage, plus roughly 25 single-branch error paths elsewhere.

## Tests that were asserting nothing

Three existing tests turned out to be silently passing:

- `_mock_surroundings` in `test_scanner.py` starts two patchers on the *same* `pywikibot.Page` attribute, so the second one wins and `self.page_mock` is stale. `isRedirectPage()` therefore returned a truthy `MagicMock` and the redirect branch of the lemma error handling never ran — while the log assertion that would have caught it was swallowed by `suppress(AssertionError)`.
- `test_no_load_model_outdated` in `test_cloud_bot.py` had the same shape; its `assertIn` never held.
- `test_alphabetic` in `test_registers.py` checked the alphabet buckets `"u"` and `"uf"`, which are not in `RE_ALPHABET` at all because u is unified to v. Switched to `"v"` / `"vf"` with the real counts.

The remaining `suppress(AssertionError)` wrappers in `test_scanner.py` are left untouched — worth a separate cleanup, since they can hide future regressions the same way.

## The 9 statements left uncovered

All unreachable. Two of them are latent bugs, left alone here because fixing them changes behaviour:

- `registers.py:89-90` — `RE_ALPHABET[idx - 1]` at `idx == 0` wraps to `"z"` instead of raising `IndexError`, so the first alphabetic register gets `before_start="z"` rather than `None`.
- `date_conversion.py:129-130` — `except IndexError` wraps a **dict** lookup (`MONTH_MAPPING[month]`), so an unknown month name raises `KeyError` instead of the intended `ValueError`.

Plain dead defensive code: `updater.py:247` (`idx - 1 < 0` cannot hold inside `if idx:`), `updater.py:263` (`get_index_of_lemma` raises `ValueError` for an unknown `Lemma`, it never returns `None`), `updater.py:310,315` (raises in branches their own flag excludes) and `volumes.py:111` (the `type` property already guarantees the regex matches).
