### PR TITLE
Convert hard RE links only for lemmas missing from register

### DIFF
--- a/service/ws_re/scanner/base.py
+++ b/service/ws_re/scanner/base.py
@@ -52,7 +52,7 @@ class ReScanner(CloudBot):
             KURZTask,  # add short description
             COKSTask,  # correct Korrekturstand if it is not correct
             SKFRTask,  # set sortkey from redirect if it has a better match
-            #HLTSTask,  # convert hard wiki links to RE siehe template
+            HLTSTask,  # convert hard wiki links to RE siehe template
             RELITask,  # remove unwanted RE cross-reference syntax
             DEALTask,  # check for dead links RE internal
             DEWPTask,  # check for dead links to Wikipedia

--- a/service/ws_re/scanner/tasks/hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/hard_links_to_siehe.py
@@ -2,6 +2,7 @@ import re
 
 import pywikibot
 
+from service.ws_re.register.registers import Registers
 from service.ws_re.scanner.tasks.base_task import ReScannerTask
 from service.ws_re.template.article import Article
 from tools.bots.logger import WikiLogger
@@ -10,6 +11,10 @@ from tools.bots.logger import WikiLogger
 class HLTSTask(ReScannerTask):
     """
     Converts hard wiki links to RE articles into the {{RE siehe}} template.
+
+    Only links whose target is NOT a lemma of the local register data are converted, the template
+    handles those gracefully. Links to known lemmas are kept as they are. Links with a section
+    anchor ("[[RE:Lemma#Abschnitt]]") are never converted, the template can't express them.
 
     Replacements:
     - "[[RE:Lemma]]" -> "{{RE siehe|Lemma}}"
@@ -20,14 +25,40 @@ class HLTSTask(ReScannerTask):
 
     def __init__(self, wiki: pywikibot.site.BaseSite, logger: WikiLogger, debug: bool = True):
         super().__init__(wiki, logger, debug)
+        self._lemma_names: set[str] | None = None
+        self._unknown_targets: set[tuple[str, str]] = set()
 
-    @classmethod
-    def _replace(cls, match: re.Match) -> str:
-        lemma = match.group(1)
+    @property
+    def lemma_names(self) -> set[str]:
+        """All lemma names of the local register data, lazily loaded on first use."""
+        if self._lemma_names is None:
+            self._lemma_names = {lemma.lemma for register in Registers().volumes.values() for lemma in register.lemmas}
+        return self._lemma_names
+
+    def _resolve_lemma(self, target: str) -> str | None:
+        """Return the register lemma a link target points to, None if there is none."""
+        normalized = target.replace("_", " ").strip()
+        if normalized in self.lemma_names:
+            return normalized
+        # MediaWiki capitalizes the first character of a page title
+        if normalized:
+            capitalized = normalized[0].upper() + normalized[1:]
+            if capitalized in self.lemma_names:
+                return capitalized
+        return None
+
+    def _replace(self, match: re.Match) -> str:
+        target = match.group(1)
         anchor = match.group(2)
+        if "#" in target:
+            return match.group(0)
+        if self._resolve_lemma(target):
+            # lemma is known in the register, the hard link stays as it is
+            return match.group(0)
+        self._unknown_targets.add((target, self.re_page.lemma_without_prefix))
         if anchor:
-            return f"{{{{RE siehe|{lemma}|{anchor}}}}}"
-        return f"{{{{RE siehe|{lemma}}}}}"
+            return f"{{{{RE siehe|{target}|{anchor}}}}}"
+        return f"{{{{RE siehe|{target}}}}}"
 
     def _fix_text(self, text: str) -> str:
         return self._link_regex.sub(self._replace, text)
@@ -43,3 +74,11 @@ class HLTSTask(ReScannerTask):
                 if fixed != part:
                     self.re_page[idx] = fixed
         return True
+
+    def finish_task(self):
+        if self._unknown_targets:
+            entries = [
+                f"[[RE:{target}]] verlinkt von [[RE:{source}]]" for target, source in sorted(self._unknown_targets)
+            ]
+            self.logger.info(f"Links converted, lemma unknown in register: {entries}")
+        super().finish_task()

--- a/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
@@ -1,16 +1,32 @@
 from testfixtures import compare
 
+from service.ws_re.register.repo import DataRepo
+from service.ws_re.register.test_base import clear_tst_path, copy_tst_data
 from service.ws_re.scanner.tasks.hard_links_to_siehe import HLTSTask
 from service.ws_re.scanner.tasks.test_base_task import TaskTestCase
 from service.ws_re.template.re_page import RePage
 
 
 class TestHLTSTask(TaskTestCase):
+    @classmethod
+    def setUpClass(cls):
+        DataRepo.mock_data(True)
+        clear_tst_path()
+
+    @classmethod
+    def tearDownClass(cls):
+        clear_tst_path(renew_path=False)
+        DataRepo.mock_data(False)
+
     def setUp(self):
         super().setUp()
+        copy_tst_data("I_1_base", "I_1")
+        copy_tst_data("authors", "authors")
+        copy_tst_data("authors_mapping", "authors_mapping")
         self.task = HLTSTask(None, self.logger)
 
     def test_replacements_in_article_text(self):
+        self.page_mock.title_str = "RE:Quelllemma"
         self.page_mock.text = """{{REDaten
 }}
 Text mit Links: [[RE:Leben(a)]] und [[RE:Leben(a)|Leben]].
@@ -25,10 +41,11 @@ Text mit Links: [[RE:Leben(a)]] und [[RE:Leben(a)|Leben]].
         self.assertIn("{{RE siehe|Leben(a)|Leben}}", after)
         self.assertNotIn("[[RE:Leben(a)]]", after)
         self.assertNotIn("[[RE:Leben(a)|Leben]]", after)
+        compare({("Leben(a)", "Quelllemma")}, self.task._unknown_targets)  # pylint: disable=protected-access
 
     def test_replacements_in_plain_text_segments(self):
         self.page_mock.text = (
-            "Vorab [[RE:Leben(a)|Leben]].\n{{REDaten}}\nText im Artikel.\n{{REAutor|Autor.}}\nNachlauf [[RE:Leben(a)]]."
+            "Vorab [[RE:Leben(a)|Leben]].\n{{REDaten}}\nText im Artikel.\n{{REAutor|Autor.}}\nNachlauf [[RE:Leben(b)]]."
         )
         re_page = RePage(self.page_mock)
 
@@ -37,7 +54,37 @@ Text mit Links: [[RE:Leben(a)]] und [[RE:Leben(a)|Leben]].
 
         full_text = str(re_page)
         self.assertIn("Vorab {{RE siehe|Leben(a)|Leben}}.", full_text)
-        self.assertIn("Nachlauf {{RE siehe|Leben(a)}}.", full_text)
+        self.assertIn("Nachlauf {{RE siehe|Leben(b)}}.", full_text)
+
+    def test_no_replacement_when_lemma_in_register(self):
+        self.page_mock.text = """{{REDaten}}
+Text mit Links: [[RE:Aal]] und [[RE:Aarassos|Leben]].
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": False}, result)
+        self.assertIn("[[RE:Aal]]", re_page[0].text)
+        self.assertIn("[[RE:Aarassos|Leben]]", re_page[0].text)
+
+    def test_no_replacement_for_register_lemma_with_underscore_or_lowercase(self):
+        self.page_mock.text = """{{REDaten}}
+Links: [[RE:Aba_1]] und [[RE:aba 2]].
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": False}, result)
+
+    def test_no_replacement_for_links_with_anchor(self):
+        self.page_mock.text = """{{REDaten}}
+Text mit Link: [[RE:Leben(a)#Abschnitt]].
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": False}, result)
+        self.assertIn("[[RE:Leben(a)#Abschnitt]]", re_page[0].text)
 
     def test_no_change_when_no_hard_links_present(self):
         self.page_mock.text = """{{REDaten}}


### PR DESCRIPTION
## What

`HLTSTask` converted every hard `[[RE:Lemma]]` link into `{{RE siehe|Lemma}}`. It now checks the link target first — against the **local register data**, not the Wikisource API — and only converts links whose target is *not* a lemma in the register.

## Behaviour

- Target not in register → converted: `[[RE:X]]` → `{{RE siehe|X}}`, `[[RE:X|Anchor]]` → `{{RE siehe|X|Anchor}}`
- Target is a known register lemma → hard link left untouched
- Link with a section anchor (`[[RE:X#Abschnitt]]`) → never converted, the template can't express it
- Lookup normalises the target (`_` → space, first character capitalised) so `[[RE:Aba_1]]` and `[[RE:aba 2]]` are recognised as the existing lemmas `Aba 1` / `Aba 2`
- The lemma name set is built lazily once per task instance from `Registers()` (`update_data=False`)
- `finish_task()` logs the converted targets together with their source page: `[[RE:X]] verlinkt von [[RE:Y]]`
- `HLTSTask` is re-enabled in the scanner task list

## Notes

- A lemma created during the same run (by `SCANTask`, which runs later) is not visible to `HLTSTask` until the next run.
- Hard links to redirects are treated as unknown lemmas and therefore converted — consequence of checking the register rather than the wiki.

## Tests

Six cases against the `I_1_base` register stub (`DataRepo.mock_data`): conversion in article text and in plain-text segments, no conversion for known lemmas, no conversion for normalised known lemmas, no conversion for anchored links, no change without hard links. Full `service/ws_re` suite green, ruff check and format clean.
