### PR TITLE
Place RE:Stammdaten überprüfen category next to inserted article

### DIFF
--- a/service/ws_re/register/importer.py
+++ b/service/ws_re/register/importer.py
@@ -152,8 +152,8 @@ class ReImporter(CloudBot):
         else:
             re_page.add_error_category(self._SHORT_TEXT_CATEGORY)
         re_page.insert(position, new_article)
+        re_page.insert(position + 1, f"[[Kategorie:{self._STORE_CATEGORY}]]")
         self.adjust_nachtrag(re_page)
-        re_page.add_error_category(self._STORE_CATEGORY)
         try:
             re_page.save(f"Automatisch ergänzter Artikel aus Band {band}")
         except ReDatenException as error:


### PR DESCRIPTION
## Summary
- `_add_article` appended the maintenance category `RE:Stammdaten überprüfen` at the end of the whole lemma page via `add_error_category`, regardless of where the newly added article got inserted in the article order.
- Now the category line is inserted directly after the new article, so it stays associated with the article that triggered it.

## Test plan
- [x] `pytest service/ws_re/register/test_importer.py` (41 passed)