### PR TITLE
Fall back to predecessor's end column for missing SPALTE_START

### DIFF
--- a/service/ws_re/register/importer.py
+++ b/service/ws_re/register/importer.py
@@ -250,7 +250,13 @@ class ReImporter(CloudBot):
             nachfolger = post_article.lemma
         else:
             nachfolger = ""
-        spalte_start = article.chapter_objects[0].start if article.chapter_objects else "OFF"
+        if article.chapter_objects:
+            spalte_start: str | int = article.chapter_objects[0].start
+        elif pre_article is not None and pre_article.chapter_objects:
+            pre_chapter = pre_article.chapter_objects[-1]
+            spalte_start = pre_chapter.end or pre_chapter.start
+        else:
+            spalte_start = "OFF"
         spalte_end: str | int = "OFF"
         if article.chapter_objects and article.chapter_objects[0].end:
             spalte_end = article.chapter_objects[0].end

--- a/service/ws_re/register/importer.py
+++ b/service/ws_re/register/importer.py
@@ -152,8 +152,8 @@ class ReImporter(CloudBot):
         else:
             re_page.add_error_category(self._SHORT_TEXT_CATEGORY)
         re_page.insert(position, new_article)
+        re_page.insert(position + 1, f"[[Kategorie:{self._STORE_CATEGORY}]]")
         self.adjust_nachtrag(re_page)
-        re_page.add_error_category(self._STORE_CATEGORY)
         try:
             re_page.save(f"Automatisch ergänzter Artikel aus Band {band}")
         except ReDatenException as error:

--- a/service/ws_re/register/test_importer.py
+++ b/service/ws_re/register/test_importer.py
@@ -152,6 +152,18 @@ class TestGetTextBackup(BaseTestRegister):
         self.assertIn("|SPALTE_END=OFF", result)
         self.assertIn("{{REAutor|OFF}}", result)
 
+    def test_start_column_falls_back_to_predecessor_end_column(self):
+        article = self._make_lemma("Main")
+        pre = self._make_lemma("Pre", chapters=[{"start": 12, "end": 14}])
+        result = ReImporter.get_text_backup("I,1", article, pre)
+        self.assertIn("|SPALTE_START=14", result)
+
+    def test_start_column_falls_back_to_predecessor_start_column_without_end(self):
+        article = self._make_lemma("Main")
+        pre = self._make_lemma("Pre", chapters=[{"start": 12}])
+        result = ReImporter.get_text_backup("I,1", article, pre)
+        self.assertIn("|SPALTE_START=12", result)
+
 
 def _article(band: str, short_text: str = "") -> str:
     return (


### PR DESCRIPTION
## Summary
- Importer logged `No start column for the article of ... in [[...]]` and skipped adding the article whenever the register had no chapter data for it.
- `get_text_backup` now falls back to the predecessor article's end column (or start column if no end) when the article itself has none, so the article can still be inserted.

## Test plan
- [x] Added unit tests covering fallback to predecessor's end column and to predecessor's start column when no end is set.
- [x] `pytest service/ws_re/register/test_importer.py` passes (43 tests).