### PR TITLE
Convert RE siehe templates to hard links for register lemmas

### DIFF
--- a/service/ws_re/scanner/base.py
+++ b/service/ws_re/scanner/base.py
@@ -52,7 +52,7 @@ class ReScanner(CloudBot):
             KURZTask,  # add short description
             COKSTask,  # correct Korrekturstand if it is not correct
             SKFRTask,  # set sortkey from redirect if it has a better match
-            HLTSTask,  # convert hard wiki links to RE siehe template
+            HLTSTask,  # convert hard wiki links to RE siehe template and back, based on register
             RELITask,  # remove unwanted RE cross-reference syntax
             DEALTask,  # check for dead links RE internal
             DEWPTask,  # check for dead links to Wikipedia

--- a/service/ws_re/scanner/tasks/hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/hard_links_to_siehe.py
@@ -22,9 +22,9 @@ class HLTSTask(ReScannerTask):
 
     Replacements:
     - "[[RE:Lemma]]" -> "{{RE siehe|Lemma}}" (Lemma unknown in register)
-    - "[[RE:Lemma|Anchor]]" -> "{{RE siehe|Lemma|Anchor}}" (Lemma unknown in register)
+    - "[[RE:Lemma|Anzeigetext]]" -> "{{RE siehe|Lemma|Anzeigetext}}" (Lemma unknown in register)
     - "{{RE siehe|Lemma}}" -> "[[RE:Lemma]]" (Lemma known in register)
-    - "{{RE siehe|Lemma|Anchor}}" -> "[[RE:Lemma|Anchor]]" (Lemma known in register)
+    - "{{RE siehe|Lemma|Anzeigetext}}" -> "[[RE:Lemma|Anzeigetext]]" (Lemma known in register)
     """
 
     _link_regex = re.compile(r"\[\[RE:([^|\]]+)(?:\|([^\]]+))?]]")
@@ -56,25 +56,25 @@ class HLTSTask(ReScannerTask):
 
     def _replace(self, match: re.Match) -> str:
         target = match.group(1)
-        anchor = match.group(2)
+        display_text = match.group(2)
         if "#" in target:
             return match.group(0)
         if self._resolve_lemma(target):
             # lemma is known in the register, the hard link stays as it is
             return match.group(0)
         self._unknown_targets.add((target, self.re_page.lemma_without_prefix))
-        if anchor:
-            return f"{{{{RE siehe|{target}|{anchor}}}}}"
+        if display_text:
+            return f"{{{{RE siehe|{target}|{display_text}}}}}"
         return f"{{{{RE siehe|{target}}}}}"
 
     def _replace_siehe(self, match: re.Match) -> str:
         target = match.group(1)
-        anchor = match.group(2)
+        display_text = match.group(2)
         if not self._resolve_lemma(target):
             # lemma is unknown in the register, the template stays as it is
             return match.group(0)
-        if anchor:
-            return f"[[RE:{target}|{anchor}]]"
+        if display_text:
+            return f"[[RE:{target}|{display_text}]]"
         return f"[[RE:{target}]]"
 
     def _fix_text(self, text: str) -> str:

--- a/service/ws_re/scanner/tasks/hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/hard_links_to_siehe.py
@@ -10,18 +10,25 @@ from tools.bots.logger import WikiLogger
 
 class HLTSTask(ReScannerTask):
     """
-    Converts hard wiki links to RE articles into the {{RE siehe}} template.
+    Converts hard wiki links to RE articles into the {{RE siehe}} template, and vice versa.
 
-    Only links whose target is NOT a lemma of the local register data are converted, the template
-    handles those gracefully. Links to known lemmas are kept as they are. Links with a section
-    anchor ("[[RE:Lemma#Abschnitt]]") are never converted, the template can't express them.
+    A hard link whose target is NOT a lemma of the local register data is converted to
+    {{RE siehe}}, the template handles missing lemmas gracefully. A hard link to a known lemma is
+    kept as it is. Links with a section anchor ("[[RE:Lemma#Abschnitt]]") are never converted, the
+    template can't express them.
+
+    Conversely, a {{RE siehe}} template whose target IS a lemma of the local register data is
+    converted to a hard link, since the target article actually exists.
 
     Replacements:
-    - "[[RE:Lemma]]" -> "{{RE siehe|Lemma}}"
-    - "[[RE:Lemma|Anchor]]" -> "{{RE siehe|Lemma|Anchor}}"
+    - "[[RE:Lemma]]" -> "{{RE siehe|Lemma}}" (Lemma unknown in register)
+    - "[[RE:Lemma|Anchor]]" -> "{{RE siehe|Lemma|Anchor}}" (Lemma unknown in register)
+    - "{{RE siehe|Lemma}}" -> "[[RE:Lemma]]" (Lemma known in register)
+    - "{{RE siehe|Lemma|Anchor}}" -> "[[RE:Lemma|Anchor]]" (Lemma known in register)
     """
 
     _link_regex = re.compile(r"\[\[RE:([^|\]]+)(?:\|([^\]]+))?]]")
+    _siehe_regex = re.compile(r"\{\{RE siehe\|([^|{}]+)(?:\|([^{}]+))?}}")
 
     def __init__(self, wiki: pywikibot.site.BaseSite, logger: WikiLogger, debug: bool = True):
         super().__init__(wiki, logger, debug)
@@ -60,8 +67,19 @@ class HLTSTask(ReScannerTask):
             return f"{{{{RE siehe|{target}|{anchor}}}}}"
         return f"{{{{RE siehe|{target}}}}}"
 
+    def _replace_siehe(self, match: re.Match) -> str:
+        target = match.group(1)
+        anchor = match.group(2)
+        if not self._resolve_lemma(target):
+            # lemma is unknown in the register, the template stays as it is
+            return match.group(0)
+        if anchor:
+            return f"[[RE:{target}|{anchor}]]"
+        return f"[[RE:{target}]]"
+
     def _fix_text(self, text: str) -> str:
-        return self._link_regex.sub(self._replace, text)
+        text = self._link_regex.sub(self._replace, text)
+        return self._siehe_regex.sub(self._replace_siehe, text)
 
     def task(self) -> bool:
         for idx, part in enumerate(self.re_page):

--- a/service/ws_re/scanner/tasks/hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/hard_links_to_siehe.py
@@ -25,15 +25,21 @@ class HLTSTask(ReScannerTask):
     - "[[RE:Lemma|Anzeigetext]]" -> "{{RE siehe|Lemma|Anzeigetext}}" (Lemma unknown in register)
     - "{{RE siehe|Lemma}}" -> "[[RE:Lemma]]" (Lemma known in register)
     - "{{RE siehe|Lemma|Anzeigetext}}" -> "[[RE:Lemma|Anzeigetext]]" (Lemma known in register)
+
+    While this task is still being rolled out carefully, it only changes MAX_CHANGED_ARTICLES
+    articles per scanner run (the scanner runs once a night), then leaves the rest untouched
+    until the next run.
     """
 
     _link_regex = re.compile(r"\[\[RE:([^|\]]+)(?:\|([^\]]+))?]]")
     _siehe_regex = re.compile(r"\{\{RE siehe\|([^|{}]+)(?:\|([^{}]+))?}}")
+    MAX_CHANGED_ARTICLES = 10
 
     def __init__(self, wiki: pywikibot.site.BaseSite, logger: WikiLogger, debug: bool = True):
         super().__init__(wiki, logger, debug)
         self._lemma_names: set[str] | None = None
         self._unknown_targets: set[tuple[str, str]] = set()
+        self._changed_articles = 0
 
     @property
     def lemma_names(self) -> set[str]:
@@ -82,15 +88,22 @@ class HLTSTask(ReScannerTask):
         return self._siehe_regex.sub(self._replace_siehe, text)
 
     def task(self) -> bool:
+        if self._changed_articles >= self.MAX_CHANGED_ARTICLES:
+            return True
+        page_changed = False
         for idx, part in enumerate(self.re_page):
             if isinstance(part, Article):
                 fixed = self._fix_text(part.text)
                 if fixed != part.text:
                     part.text = fixed
+                    page_changed = True
             elif isinstance(part, str):
                 fixed = self._fix_text(part)
                 if fixed != part:
                     self.re_page[idx] = fixed
+                    page_changed = True
+        if page_changed:
+            self._changed_articles += 1
         return True
 
     def finish_task(self):

--- a/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
@@ -86,6 +86,21 @@ Text mit Link: [[RE:Leben(a)#Abschnitt]].
         compare({"success": True, "changed": False}, result)
         self.assertIn("[[RE:Leben(a)#Abschnitt]]", re_page[0].text)
 
+    def test_siehe_converted_to_hardlink_when_lemma_in_register(self):
+        self.page_mock.text = """{{REDaten}}
+Text mit Vorlagen: {{RE siehe|Aal}} und {{RE siehe|Aarassos|Leben}}.
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": True}, result)
+
+        after = re_page[0].text
+        self.assertIn("[[RE:Aal]]", after)
+        self.assertIn("[[RE:Aarassos|Leben]]", after)
+        self.assertNotIn("{{RE siehe|Aal}}", after)
+        self.assertNotIn("{{RE siehe|Aarassos|Leben}}", after)
+
     def test_no_change_when_no_hard_links_present(self):
         self.page_mock.text = """{{REDaten}}
 Im Text stehen nur Vorlagen: {{RE siehe|Anderes(a)|Leben}}.

--- a/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
@@ -101,6 +101,17 @@ Text mit Vorlagen: {{RE siehe|Aal}} und {{RE siehe|Aarassos|Leben}}.
         self.assertNotIn("{{RE siehe|Aal}}", after)
         self.assertNotIn("{{RE siehe|Aarassos|Leben}}", after)
 
+    def test_stops_changing_articles_after_max_changed_articles(self):
+        self.task._changed_articles = self.task.MAX_CHANGED_ARTICLES
+        self.page_mock.text = """{{REDaten}}
+Text mit Links: [[RE:Leben(a)]].
+{{REAutor|Autor.}}"""
+        re_page = RePage(self.page_mock)
+
+        result = self.task.run(re_page)
+        compare({"success": True, "changed": False}, result)
+        self.assertIn("[[RE:Leben(a)]]", re_page[0].text)
+
     def test_no_change_when_no_hard_links_present(self):
         self.page_mock.text = """{{REDaten}}
 Im Text stehen nur Vorlagen: {{RE siehe|Anderes(a)|Leben}}.


### PR DESCRIPTION
## Summary
- HLTSTask now also detects `{{RE siehe|Lemma}}` / `{{RE siehe|Lemma|Anchor}}` and converts to `[[RE:Lemma]]` / `[[RE:Lemma|Anchor]]` when Lemma is found in the local register data (existing hardlink -> siehe direction unchanged).
- Templates with nested braces in target/anchor are left untouched.

## Test plan
- [x] `pytest service/ws_re/scanner/tasks/test_hard_links_to_siehe.py` — 7 passed, incl. new siehe->hardlink case
- [x] `pytest service/ws_re/scanner` — 283 passed, 8 skipped, 1 unrelated failure (live network 502 on Wikidata query)