### PR TITLE
Hide RE: prefix on hard links produced or kept by HLTSTask

### DIFF
--- a/service/ws_re/scanner/tasks/hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/hard_links_to_siehe.py
@@ -23,7 +23,8 @@ class HLTSTask(ReScannerTask):
     Replacements:
     - "[[RE:Lemma]]" -> "{{RE siehe|Lemma}}" (Lemma unknown in register)
     - "[[RE:Lemma|Anzeigetext]]" -> "{{RE siehe|Lemma|Anzeigetext}}" (Lemma unknown in register)
-    - "{{RE siehe|Lemma}}" -> "[[RE:Lemma]]" (Lemma known in register)
+    - "[[RE:Lemma]]" -> "[[RE:Lemma|Lemma]]" (Lemma known in register)
+    - "{{RE siehe|Lemma}}" -> "[[RE:Lemma|Lemma]]" (Lemma known in register)
     - "{{RE siehe|Lemma|Anzeigetext}}" -> "[[RE:Lemma|Anzeigetext]]" (Lemma known in register)
 
     While this task is still being rolled out carefully, it only changes MAX_CHANGED_ARTICLES
@@ -66,8 +67,8 @@ class HLTSTask(ReScannerTask):
         if "#" in target:
             return match.group(0)
         if self._resolve_lemma(target):
-            # lemma is known in the register, the hard link stays as it is
-            return match.group(0)
+            # lemma is known in the register, keep the hard link but hide the "RE:" prefix
+            return f"[[RE:{target}|{display_text or target}]]"
         self._unknown_targets.add((target, self.re_page.lemma_without_prefix))
         if display_text:
             return f"{{{{RE siehe|{target}|{display_text}}}}}"
@@ -79,9 +80,8 @@ class HLTSTask(ReScannerTask):
         if not self._resolve_lemma(target):
             # lemma is unknown in the register, the template stays as it is
             return match.group(0)
-        if display_text:
-            return f"[[RE:{target}|{display_text}]]"
-        return f"[[RE:{target}]]"
+        # keep the "RE:" prefix out of the rendered text
+        return f"[[RE:{target}|{display_text or target}]]"
 
     def _fix_text(self, text: str) -> str:
         text = self._link_regex.sub(self._replace, text)

--- a/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
+++ b/service/ws_re/scanner/tasks/test_hard_links_to_siehe.py
@@ -56,25 +56,27 @@ Text mit Links: [[RE:Leben(a)]] und [[RE:Leben(a)|Leben]].
         self.assertIn("Vorab {{RE siehe|Leben(a)|Leben}}.", full_text)
         self.assertIn("Nachlauf {{RE siehe|Leben(b)}}.", full_text)
 
-    def test_no_replacement_when_lemma_in_register(self):
+    def test_hardlink_gets_display_text_when_lemma_in_register(self):
         self.page_mock.text = """{{REDaten}}
 Text mit Links: [[RE:Aal]] und [[RE:Aarassos|Leben]].
 {{REAutor|Autor.}}"""
         re_page = RePage(self.page_mock)
 
         result = self.task.run(re_page)
-        compare({"success": True, "changed": False}, result)
-        self.assertIn("[[RE:Aal]]", re_page[0].text)
+        compare({"success": True, "changed": True}, result)
+        self.assertIn("[[RE:Aal|Aal]]", re_page[0].text)
         self.assertIn("[[RE:Aarassos|Leben]]", re_page[0].text)
 
-    def test_no_replacement_for_register_lemma_with_underscore_or_lowercase(self):
+    def test_hardlink_for_register_lemma_with_underscore_or_lowercase_gets_display_text(self):
         self.page_mock.text = """{{REDaten}}
 Links: [[RE:Aba_1]] und [[RE:aba 2]].
 {{REAutor|Autor.}}"""
         re_page = RePage(self.page_mock)
 
         result = self.task.run(re_page)
-        compare({"success": True, "changed": False}, result)
+        compare({"success": True, "changed": True}, result)
+        self.assertIn("[[RE:Aba_1|Aba_1]]", re_page[0].text)
+        self.assertIn("[[RE:aba 2|aba 2]]", re_page[0].text)
 
     def test_no_replacement_for_links_with_anchor(self):
         self.page_mock.text = """{{REDaten}}
@@ -96,7 +98,7 @@ Text mit Vorlagen: {{RE siehe|Aal}} und {{RE siehe|Aarassos|Leben}}.
         compare({"success": True, "changed": True}, result)
 
         after = re_page[0].text
-        self.assertIn("[[RE:Aal]]", after)
+        self.assertIn("[[RE:Aal|Aal]]", after)
         self.assertIn("[[RE:Aarassos|Leben]]", after)
         self.assertNotIn("{{RE siehe|Aal}}", after)
         self.assertNotIn("{{RE siehe|Aarassos|Leben}}", after)


### PR DESCRIPTION
## Summary
- Hard links to lemmas known in the register now always carry a display text equal to the target, so the "RE:" prefix is never rendered: `[[RE:Lemma]]` -> `[[RE:Lemma|Lemma]]`.
- Applies both when a plain hard link is kept as-is (register-known) and when a `{{RE siehe|Lemma}}` template is converted to a hard link.

## Test plan
- [x] `pytest service/ws_re/scanner/tasks/test_hard_links_to_siehe.py` — 8 passed
- [x] `pytest service/ws_re/scanner` — 285 passed, 8 skipped