### PR TITLE
re-stammdaten-check: guard against missing REAutor trailing period

### DIFF
--- a/.claude/skills/re-stammdaten-check/SKILL.md
+++ b/.claude/skills/re-stammdaten-check/SKILL.md
@@ -245,6 +245,21 @@ as a diff. Do not assume an already-plausible full name is correct. (Regression:
 kept `Rudolf Güngerich` when the print reads `[Güngerich.]` — it was never re-checked against the
 scan.)
 
+**Hard rule: every `reautor_fix` you write ends with `.` — no exceptions except the literal
+sentinel `OFF` and the band-disambiguation form `Autor.|Band`.** The printed signature inside
+`[ ... ]` always closes with a period before the `]`; if your fix string doesn't have one, you
+copied the name but dropped the punctuation — go back and fix it, don't ship it. This is not a
+cosmetic nit: a batch run (2026-08-14) shipped REAutor fixes with the period stripped on most
+entries, and the user had to catch it after the fact. Two backstops, both required:
+- **Subagents**: before writing `findings_NN.json`, re-read each `reautor_fix` value you're about
+  to emit and confirm it ends in `.` (unless `OFF`/disambiguated). Fix it inline if not.
+- **Aggregation**: `scripts/aggregate_findings.py` now hard-guards this — it appends a missing
+  `.` to any `reautor_fix` that lacks one (excluding `OFF` and `|`-disambiguated forms) and prints
+  a `REAUTOR missing trailing period, auto-fixed` list. **Always run aggregate_findings.py and
+  read that list before applying edits** — a non-empty list means subagents are dropping periods
+  again and the root cause (prompt/instructions to that subagent batch) should be checked, not
+  just silently patched.
+
 **Do NOT overwrite these REAutor forms — they are deliberate author-template syntax, not raw
 signatures (flag for the user instead):**
 - **Band-disambiguation `Autor|Band`** (e.g. `{{REAutor|Nagl.|VII A,2}}`) — the `|VII A,2`

--- a/.claude/skills/re-stammdaten-check/scripts/aggregate_findings.py
+++ b/.claude/skills/re-stammdaten-check/scripts/aggregate_findings.py
@@ -51,8 +51,24 @@ def main():
                 if isinstance(hw, dict) and hw.get('move_target'):
                     e.setdefault('title_fix', hw['move_target'])
             rows.append(e)
+    # hard guard: a printed REAutor signature always ends in "." (except the literal OFF
+    # sentinel). A subagent that dropped the period is a common, easy-to-miss mistake — catch
+    # it here instead of letting it reach the edit pass.
+    period_fixed = []
+    for r in rows:
+        fix = r.get('reautor_fix')
+        if fix and fix != 'OFF' and '|' not in fix and not fix.endswith('.'):
+            r['reautor_fix'] = fix + '.'
+            period_fixed.append((r['title'], fix))
+
     json.dump(rows, open(f'{outdir}/all_findings.json', 'w'), ensure_ascii=False, indent=1)
     print(f'total findings: {len(rows)}\n')
+
+    if period_fixed:
+        print(f'=== REAUTOR missing trailing period, auto-fixed: {len(period_fixed)}')
+        for title, fix in period_fixed:
+            print(f'  {title:24} {fix!r} -> {fix!r}.')
+        print()
 
     def show(label, pred, fmt):
         hits = [r for r in rows if pred(r)]


### PR DESCRIPTION
## Summary
- Last re-stammdaten-check batch dropped the trailing "." on most REAutor fixes.
- SKILL.md: hard rule — every reautor_fix must end with "." (except OFF / band-disambiguated).
- aggregate_findings.py: auto-appends missing period, prints warning list to review before applying edits.

## Test plan
- [ ] Run next re-stammdaten-check batch, confirm all_findings.json REAutor entries end with "."